### PR TITLE
Tree needs to be an array for JSX

### DIFF
--- a/h.js
+++ b/h.js
@@ -3,6 +3,8 @@ module.exports = function (tag, data, tree) {
         svg(tag, data, tree)
     }
 
+    tree = Array.isArray(tree) ? tree : [tree];
+
     return {
         tag: tag,
         data: data || {},


### PR DESCRIPTION
With the follow example using JSX the code will fail, hence the need to cast the `tree` argument as an array if not already.

```jsx
import { h, app } from 'hyperapp';

const model = {};

const update ={};

const view = (model, msg) => (<div><h1>Test</h1></div>);

app({model, view, update});
```
