### PR TITLE
Prevent default browser behaviour compliant with specs.

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ module.exports = function (options) {
 
                 } else {
                     msg.setLocation(target.pathname)
-                    return false
+                    e.preventDefault()
                 }
             }
         }


### PR DESCRIPTION
As specified in the DOM 2 Events specification.
I also find this more transparent and understandable.

It's a minor thing, and the downside is a few more characters.
Feel free to close RR if you disagree.

_Thanks for your work on HyperApp. 🥇_