### PR TITLE
Add .editorconfig with tab indent_style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This should define clearly what the preferred indent style is for the project, and make it easier for (most) editors to adjust automatically.