### PR TITLE
Use ES6 rest parameter syntax

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -1,10 +1,6 @@
-export default function (tag, data) {
+export default function (tag, data, ...children) {
 	data = data || {}
 
-	var children = []
-	children.push.apply(children, arguments)
-	children.shift()
-	children.shift()
 	var head = children[0]
 
 	for (var name in data) {


### PR DESCRIPTION
The code is simpler and easier to read, since you don't have to convert the array-like ```arguments``` object into a real array and shift the two first arguments. 

Besides that, it's less code.