### PR TITLE
Makes * the fallback route if no matching route is found

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -61,7 +61,11 @@ export default function (render, options) {
             }
         }
 
-        return routes["*"] || function(m,a) { return "404 Not Found" }
+        if (!routes["*"]) {
+          throw 'No matching route for ' + path
+        }
+
+        return routes["*"]
     }
 
     function regexify(path) {

--- a/src/router.js
+++ b/src/router.js
@@ -41,6 +41,10 @@ export default function (render, options) {
         for (var route in routes) {
             var re = regexify(route), params = {}, match
 
+            if (route === "*") {
+                continue
+            }
+
             path.replace(new RegExp(re.re, "g"), function () {
                 for (var i = 1; i < arguments.length - 2; i++) {
                     params[re.keys.shift()] = arguments[i]
@@ -57,13 +61,11 @@ export default function (render, options) {
             }
         }
 
-        return routes["*"]
+        return routes["*"] || function(m,a) { return "404 Not Found" }
     }
 
     function regexify(path) {
-        var keys = []
-        var re = path === '*' ?
-            '.*' : "^" + path
+        var keys = [], re = "^" + path
             .replace(/\//g, "\\/")
             .replace(/:([A-Za-z0-9_]+)/g, function (_, key) {
                 keys.push(key)

--- a/src/router.js
+++ b/src/router.js
@@ -57,11 +57,13 @@ export default function (render, options) {
             }
         }
 
-        return routes["/"]
+        return routes["*"]
     }
 
     function regexify(path) {
-        var keys = [], re = "^" + path
+        var keys = []
+        var re = path === '*' ?
+            '.*' : "^" + path
             .replace(/\//g, "\\/")
             .replace(/:([A-Za-z0-9_]+)/g, function (_, key) {
                 keys.push(key)

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -22,7 +22,6 @@ describe("Router", () => {
             "/home": _ => "Tokyo",
             "/repos/hyperapp": _ => "Godzilla",
             "/h/y/p/e/r/a/p/p": _ => "Supersonic",
-            "*": _ => "Boston",
         }
 
         Object.keys(view).forEach(path => {
@@ -31,6 +30,19 @@ describe("Router", () => {
                 path,
                 expected: view[path]
             })
+        })
+    })
+
+    it("defaults non matching route", () => {
+        const view = {
+            "/": _ => "Earth",
+            "*": _ => "Boston",
+        }
+
+        matchRouteWithPath({
+            view,
+            path: "/will/not/match",
+            expected: view["*"]
         })
     })
 

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -18,9 +18,11 @@ describe("Router", () => {
 
     it("matches complete routes", () => {
         const view = {
+            "/": _ => "Earth",
             "/home": _ => "Tokyo",
             "/repos/hyperapp": _ => "Godzilla",
             "/h/y/p/e/r/a/p/p": _ => "Supersonic",
+            "*": _ => "Boston",
         }
 
         Object.keys(view).forEach(path => {
@@ -34,10 +36,10 @@ describe("Router", () => {
 
     it("matches routes w/ slugs", () => {
         const view = {
-            "/": _ => true,
             "/:key": (model, actions, { key }) => `Key:${key}`,
             "/repos/:id": (model, actions, { id }) => `Repos/Id:${id}`,
             "/:a/:b/:c": (model, actions, { a, b, c }) => `a:${a}/b:${b}/c:${c}`,
+            "*": _ => true,
         };
 
         matchRouteWithPath({
@@ -61,7 +63,7 @@ describe("Router", () => {
         matchRouteWithPath({
             view,
             path: "/not/going/to/match",
-            expected: view["/"]
+            expected: view["*"]
         })
     })
 


### PR DESCRIPTION
As a response to https://github.com/hyperapp/hyperapp/issues/109. Actions taken:

- match function now returns `routes["*"]` when no route is found
- regexify function now returns a regex that will match `.*` when it is given the path `*` 
- Added tests for just `/` route 
- Added `*` route to both tests `view` object

Tests are passing but I would like to discuss if any of the logic could be tidied up!