### PR TITLE
Internal routing hook for <a href=/*>

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -26,7 +26,25 @@ export default function (options) {
         addEventListener("popstate", function () {
           actions.router.match(location.pathname)
         })
-      }
+      },
+      function (_, actions) {
+        addEventListener("click", function (e) {
+          if (e.metaKey || e.shiftKey || e.ctrlKey || e.altKey) return
+          var target = e.target
+          while (target && target.localName !== "a") {
+            target = target.parentNode
+          }
+          if (target && target.host === location.host && !target.hasAttribute("data-no-routing")) {
+            var element = document.querySelector(target.hash === "" ? element : target.hash)
+            if (element) {
+              element.scrollIntoView(true)
+            } else {
+              e.preventDefault()
+              actions.router.go(target.pathname)
+            }
+          }
+        })
+      },
     ]
   }
 }


### PR DESCRIPTION
This behavior was lost during the router refactor. It was quite a nice feature of the router, offering an intuitive means of navigating between views.
```html
<a href='/'>Home</a> <!-- Prevents page reload because /* indicates internal route
```
Is this the kind of thing you'd expect to see as plugin now?
```es6
export const Interlink = app => ({
  subscriptions: [
    (m,a) => {
      window.addEventListener("click", function (e) {
        if (e.metaKey || e.shiftKey || e.ctrlKey || e.altKey) return
        var target = e.target
        while (target && target.localName !== "a") {
          target = target.parentNode
        }
        if (target && target.host === location.host && !target.hasAttribute("data-no-routing")) {
          var element = document.querySelector(target.hash === "" ? element : target.hash)
          if (element) {
            element.scrollIntoView(true)
          } else {
            e.preventDefault()
            a.router.go(target.pathname)
          }
        }
      })
    },
  ]
})
```
Or is it suggested that the developer use `a` tag but with `onclick` instead of `href`
```jsx
<a onclick={e => actions.router.go('/')}>Home</a>
```
Or make a component out of it like
```jsx
export const Link = href =>
  <a href={href} onclick={e => e.preventDefault() || a.router.go(href)}>Internal Link</a>
```
I'm not entirely sure which option to choose as a convention (for myself at least) going forward. Regardless of personal preference, might it be worth promoting a _recommended_ way of navigating between views? Seeing as it is a common common action in many applications.

This probably should have been posted as an issue for discussion but the changed code here is functional and mergable in case it is decided that this is something that should come out the box.