### PR TITLE
Support camelCase lifecycle/DOM event keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .vscode/
 
 # Logs
-.log*
+*.log*
 yarn.lock
 
 # Misc

--- a/src/app.js
+++ b/src/app.js
@@ -171,7 +171,7 @@ export default function (app) {
         : document.createElement(node.tag)
 
       for (var name in node.data) {
-        if (name === "oncreate") {
+        if (name === "onCreate") {
           defer(node.data[name], element)
         } else {
           setElementData(element, name, node.data[name])
@@ -233,7 +233,7 @@ export default function (app) {
       if (value === undefined) {
         removeElementData(element, name, oldValue)
 
-      } else if (name === "onupdate") {
+      } else if (name === "onUpdate") {
         defer(value, element)
 
       } else if (
@@ -263,8 +263,8 @@ export default function (app) {
 
       batch.push(parent.removeChild.bind(parent, element))
 
-      if (oldNode && oldNode.data && oldNode.data.onremove) {
-        defer(oldNode.data.onremove, element)
+      if (oldNode && oldNode.data && oldNode.data.onRemove) {
+        defer(oldNode.data.onRemove, element)
       }
 
     } else if (shouldUpdate(node, oldNode)) {

--- a/src/app.js
+++ b/src/app.js
@@ -203,7 +203,7 @@ export default function (app) {
       }
 
     } else if (name[0] === "o" && name[1] === "n") {
-      var event = name.substr(2)
+      var event = name.substr(2).toLowerCase()
 
       element.removeEventListener(event, oldValue)
       element.addEventListener(event, value)

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -707,11 +707,11 @@ describe("app", () => {
   })
 
   describe("lifecycle methods", () => {
-    it("fires oncreate", done => {
+    it("fires onCreate", done => {
       app({
         model: 1,
         view: model => h("div", {
-          oncreate: e => {
+          onCreate: e => {
             expect(model).toBe(1)
             done()
           }
@@ -719,11 +719,11 @@ describe("app", () => {
       })
     })
 
-    it("fires onupdate", done => {
+    it("fires onUpdate", done => {
       app({
         model: 1,
         view: model => h("div", {
-          onupdate: e => {
+          onUpdate: e => {
             expect(model).toBe(2)
             done()
           }
@@ -737,11 +737,11 @@ describe("app", () => {
       })
     })
 
-    it("fires onremove", done => {
+    it("fires onRemove", done => {
       const treeA = h("ul", {},
         h("li", {}, "foo"),
         h("li", {
-          onremove: _ => {
+          onRemove: _ => {
             done()
           }
         }, "bar"))


### PR DESCRIPTION
Backstory: 

When trying to adhere to Typescripts DOM library typings (and potentially other vdom implementations), it is expecting camelCased names for event handlers, e.g. `onInput` rather than `oninput`. When this property key is parsed by hyperapp and the `on` prefix is removed, we are potentially left with capitalized event names.

Changes:

This PR forces lowercased event names. According to https://developer.mozilla.org/en-US/docs/Web/Events event names are all lowercased, so this should be a safe change.

I did not see any tests surrounding event handling, so I didn't alter anything there. If this is something that should be tested I'd be happy to add it.