### PR TITLE
Enable component nesting with own model and actions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -124,28 +124,33 @@ export default function (app) {
     batch = []
   }
 
-  function merge(a, b, into) {
-    var obj = into? a: {}
-    var key
+  function merge(a, b) {
+    var obj = {}
 
     if (isPrimitive(b) || Array.isArray(b)) {
       return b
     }
 
-    for (key in a) {
-      obj[key] = a[key]
-    }
-    for (key in b) {
-      obj[key] = b[key]
-    }
+    assign(obj, a)
+    assign(obj, b)
 
     return obj
   }
 
+  function assign(obj, src) {
+    var key
+    for(key in src) {
+      obj[key] = src[key]
+    }
+  }
+
   function updateModel(modelFragment, newModelFragment) {
     var isRoot = modelFragment === model;
-    var merged = merge(modelFragment, newModelFragment, !isRoot);
-    model = isRoot? merged: model;
+    var merged = isRoot
+      ? merge(modelFragment, newModelFragment)
+      : assign(modelFragment, newModelFragment)
+
+    model = isRoot? merged: model
   }
 
   function isPrimitive(type) {
@@ -206,9 +211,7 @@ export default function (app) {
 
   function setElementData(element, name, value, oldValue) {
     if (name === "style") {
-      for (var i in value) {
-        element.style[i] = value[i]
-      }
+      assign(element.style, value)
 
     } else if (name[0] === "o" && name[1] === "n") {
       var event = name.substr(2)

--- a/src/app.js
+++ b/src/app.js
@@ -138,8 +138,7 @@ export default function (app) {
   }
 
   function assign(obj, src) {
-    var key
-    for(key in src) {
+    for(var key in src) {
       obj[key] = src[key]
     }
   }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -329,6 +329,47 @@ describe("app", () => {
         view: _ => h("div", {}, "")
       })
     })
+
+    it("allows to pass a model fragment into an action", () => {
+      app({
+        model: {
+          todos: [{id: 1}]
+        },
+        actions: {
+          updateTodo: (todo, text) => ({text})
+        },
+        view: model => h("div", {}, `${model.todos[0].text}`),
+        subscriptions: [
+          (model, actions) => actions.updateTodo('foo', model.todos[0])
+        ]
+      })
+
+      expectHTMLToBe(`
+					<div>
+						<div>foo</div>
+					</div>
+				`)
+    })
+
+    it("passes scoped actions when they are passed", () => {
+      app({
+        model: {
+          todos: [{id: 1}]
+        },
+        actions: {
+          todos: {
+            update: (_, d, actions) => {
+              expect(Object.keys(actions)).toEqual(['update'])
+            }
+          },
+          other: _ => _
+        },
+        view: _ => h("div", {}, ''),
+        subscriptions: [
+          (model, actions) => actions.todos.update('foo', model, actions.todos)
+        ]
+      })
+    })
   })
 
   describe("hooks", () => {


### PR DESCRIPTION
Hyperapp is heavily inspired by Elm, however it lacks one of its best features.
Elm enables to compose applications by nesting components, which themselves could work as separate apps.
In Hyperapp a nested component must know the app's model tree structure to work correctly.
This PR enables actions to take 2 additional arguments: the model they are working on & the actions they can trigger, hence they can be made fully independent of the whole app tree & reusable. The only limitation here is that their state must be an object to easily update it when necessary.
This came with a cost of making the internal model mutable (doesn't matter as long as actions/subscriptions don't modify it as a side effect - it would break anyway).

An analog of Elm's App.map would come in handy here, not included to keep the footprint small.