### PR TITLE
Retain selection position on element value update

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -208,7 +208,7 @@ export default function (app) {
       element.removeEventListener(event, oldValue)
       element.addEventListener(event, value)
 
-    } else if (name === "value" && "selectionEnd" in element && "selectionStart" in element) {
+    } else if (name === "value" && "selectionEnd" in element) {
       var selectionEnd = element.selectionEnd
       var selectionStart = element.selectionStart
 

--- a/src/app.js
+++ b/src/app.js
@@ -209,11 +209,8 @@ export default function (app) {
       element.addEventListener(event, value)
 
     } else if (name === "value" && "selectionEnd" in element) {
-      var selectionEnd = element.selectionEnd
-      var selectionStart = element.selectionStart
-
       element.setAttribute(name, value)
-      element.setSelectionRange(selectionStart, selectionEnd)
+      element.setSelectionRange(element.selectionStart, element.selectionEnd)
 
     } else {
       if (value === "false" || value === false) {

--- a/src/app.js
+++ b/src/app.js
@@ -213,8 +213,7 @@ export default function (app) {
       var selectionStart = element.selectionStart
 
       element.setAttribute(name, value)
-      element.setAttribute("selectionEnd", selectionEnd)
-      element.setAttribute("selectionStart", selectionStart)
+      element.setSelectionRange(selectionStart, selectionEnd)
 
     } else {
       if (value === "false" || value === false) {

--- a/src/app.js
+++ b/src/app.js
@@ -208,6 +208,14 @@ export default function (app) {
       element.removeEventListener(event, oldValue)
       element.addEventListener(event, value)
 
+    } else if (name === "value" && "selectionEnd" in element && "selectionStart" in element) {
+      var selectionEnd = element.selectionEnd
+      var selectionStart = element.selectionStart
+
+      element.setAttribute(name, value)
+      element.setAttribute("selectionEnd", selectionEnd)
+      element.setAttribute("selectionStart", selectionStart)
+
     } else {
       if (value === "false" || value === false) {
         element.removeAttribute(name)

--- a/src/app.js
+++ b/src/app.js
@@ -208,10 +208,6 @@ export default function (app) {
       element.removeEventListener(event, oldValue)
       element.addEventListener(event, value)
 
-    } else if (name === "value" && "selectionEnd" in element) {
-      element.setAttribute(name, value)
-      element.setSelectionRange(element.selectionStart, element.selectionEnd)
-
     } else {
       if (value === "false" || value === false) {
         element.removeAttribute(name)
@@ -222,7 +218,19 @@ export default function (app) {
         if (element.namespaceURI !== "http://www.w3.org/2000/svg") {
           // SVG element's props are read only in strict mode.
 
+          var oldSelStart, oldSelEnd
+          var type = element.type
+
+          if (type && type.substr(0, 4) === "text") {
+            oldSelStart = element.selectionStart
+            oldSelEnd = element.selectionEnd
+          }
+
           element[name] = value
+
+          if (oldSelStart >= 0) {
+            element.setSelectionRange(oldSelStart, oldSelEnd)
+          }
         }
       }
     }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -211,7 +211,7 @@ describe("app", () => {
       })
     })
 
-    it("keeps selectionStart and selectionEnd properties intact on update", () => {
+    it("keeps selectionStart and selectionEnd properties on text inputs intact on update", () => {
       app({
         model: "foo",
         actions: {
@@ -236,6 +236,33 @@ describe("app", () => {
         ]
       })
     })
+
+    it("keeps selectionStart and selectionEnd properties on textarea elements intact on update", () => {
+      app({
+        model: "foo",
+        actions: {
+          changeValue: model => "bar"
+        },
+        view: model => h("textarea", { class: "selection-test", value: model }),
+        subscriptions: [
+          (_, actions) => {
+            const textareaEl = document.querySelector(".selection-test")
+
+            expect(textareaEl.selectionStart).toBe(0)
+            expect(textareaEl.selectionEnd).toBe(0)
+
+            textareaEl.selectionStart = 2;
+            textareaEl.selectionEnd = 2;
+
+            actions.changeValue()
+
+            expect(textareaEl.selectionStart).toBe(2)
+            expect(textareaEl.selectionEnd).toBe(2)
+          }
+        ]
+      })
+    })
+
 
     it("removes node/s when a container's number of children is different", () => {
       app({

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -215,7 +215,7 @@ describe("app", () => {
       app({
         model: "foo",
         actions: {
-          toggle: model => "fOo"
+          changeValue: model => "bar"
         },
         view: model => h("input", { class: "selection-test", value: model }),
         subscriptions: [
@@ -228,7 +228,7 @@ describe("app", () => {
             inputEl.selectionStart = 2;
             inputEl.selectionEnd = 2;
 
-            actions.toggle()
+            actions.changeValue()
 
             expect(inputEl.selectionStart).toBe(2)
             expect(inputEl.selectionEnd).toBe(2)

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -211,6 +211,32 @@ describe("app", () => {
       })
     })
 
+    it("keeps selectionStart and selectionEnd properties intact on update", () => {
+      app({
+        model: "foo",
+        actions: {
+          toggle: model => "fOo"
+        },
+        view: model => h("input", { class: "selection-test", value: model }),
+        subscriptions: [
+          (_, actions) => {
+            const inputEl = document.querySelector(".selection-test")
+
+            expect(inputEl.selectionStart).toBe(0)
+            expect(inputEl.selectionEnd).toBe(0)
+
+            inputEl.selectionStart = 2;
+            inputEl.selectionEnd = 2;
+
+            actions.toggle()
+
+            expect(inputEl.selectionStart).toBe(2)
+            expect(inputEl.selectionEnd).toBe(2)
+          }
+        ]
+      })
+    })
+
     it("removes node/s when a container's number of children is different", () => {
       app({
         model: true,


### PR DESCRIPTION
If setElementData updates the value of an element that has selectionEnd
and selectionStart properties it keeps the old values. This fixes a
"bug" in hyperapp which stops the user from editing text in inputs
properly.

Added tests to cover this, open to opinions on other ways of doing this.