### PR TITLE
Implement event/hook emitter

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,13 +26,9 @@ export default function (app) {
       init(actions, obj)
     }
 
-    if (obj = plugin.beforeRender) {
-      emitter.on('render', plugin.beforeRender)
-    }
+    emitter.on('render', plugin.beforeRender)
 
-    if (obj = plugin.onLoad) {
-      emitter.on('load', obj)
-    }
+    emitter.on('load', plugin.onLoad)
   }
 
   load(function () {
@@ -322,9 +318,10 @@ export default function (app) {
       },
 
       emit: function(type) {
-        var args = Array.prototype.slice.call(arguments, 1);
-        (all[type] || []).map(function(handler) { handler.apply(null, args) });
-        (all['*'] || []).map(function(handler) { handler.apply(null, args) });
+        var args = Array.prototype.slice.call(arguments, 1)
+        var handler = function(cb) { cb.apply(null, args) }
+        ;(all[type] || []).map(handler)
+        ;(all['*'] || []).map(handler)
       }
     }
   }

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ export default function (app) {
     return ""
   }
 
+  var emitter = emitter()
   var model
   var actions = {}
   var hooks = {
@@ -329,6 +330,26 @@ export default function (app) {
     }
 
     return element
+  }
+
+  function emitter(all) {
+    all = all || Object.create(null)
+
+    return {
+      on(type, handler) {
+        (all[type] || (all[type] = [])).push(handler)
+      },
+
+      off(type, handler) {
+        let e = all[type] || (all[type] = [])
+        e.splice(e.indexOf(handler) >>> 0, 1)
+      },
+
+      emit(type, ...evt) {
+        (all[type] || []).map((handler) => { handler(...evt) })
+        (all['*'] || []).map((handler) => { handler(type, ...evt) })
+      }
+    }
   }
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -8,9 +8,6 @@ export default function (app) {
   var emitter = emitter()
   var model
   var actions = {}
-  var hooks = {
-    onRender: []
-  }
 
   var node
   var root
@@ -29,12 +26,10 @@ export default function (app) {
       init(actions, obj)
     }
 
+    if (obj = plugin.beforeRender) {
+      emitter.on('render', plugin.beforeRender)
     }
 
-    if (obj = plugin.hooks) {
-      Object.keys(obj).map(function (key) {
-        hooks[key].push(obj[key])
-      })
     if (obj = plugin.onLoad) {
       emitter.on('load', obj)
     }
@@ -87,8 +82,8 @@ export default function (app) {
   }
 
   function render(model, view) {
-    hooks.onRender.map(function (cb) {
-      view = cb(model, view)
+    emitter.emit('render', model, view, function(response) {
+      view = response
     })
 
     element = patch(root, element, node, node = view(model, actions))

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ export default function (app) {
     onUpdate: [],
     onRender: []
   }
-  var subscriptions = []
+  var loaders = []
 
   var node
   var root
@@ -33,8 +33,8 @@ export default function (app) {
       init(actions, obj)
     }
 
-    if (obj = plugin.subscriptions) {
-      subscriptions = subscriptions.concat(obj)
+    if (obj = plugin.onLoad) {
+      loaders.push(obj)
     }
 
     if (obj = plugin.hooks) {
@@ -49,8 +49,8 @@ export default function (app) {
 
     render(model, view)
 
-    subscriptions.map(function (cb) {
-      cb(model, actions, error)
+    loaders.map(function (cb) {
+      cb(model, actions, emitter)
     })
   })
 
@@ -336,18 +336,19 @@ export default function (app) {
     all = all || Object.create(null)
 
     return {
-      on(type, handler) {
+      on: function(type, handler) {
         (all[type] || (all[type] = [])).push(handler)
       },
 
-      off(type, handler) {
-        let e = all[type] || (all[type] = [])
+      off: function(type, handler) {
+        var e = all[type] || (all[type] = [])
         e.splice(e.indexOf(handler) >>> 0, 1)
       },
 
-      emit(type, ...evt) {
-        (all[type] || []).map((handler) => { handler(...evt) })
-        (all['*'] || []).map((handler) => { handler(type, ...evt) })
+      emit: function(type) {
+        var args = Array.prototype.slice.call(arguments, 1)
+        (all[type] || []).map(function(handler) { handler(args) })
+        (all['*'] || []).map(function(handler) { handler(type, args) })
       }
     }
   }

--- a/src/app.js
+++ b/src/app.js
@@ -11,7 +11,6 @@ export default function (app) {
   var hooks = {
     onRender: []
   }
-  var loaders = []
 
   var node
   var root
@@ -30,14 +29,14 @@ export default function (app) {
       init(actions, obj)
     }
 
-    if (obj = plugin.onLoad) {
-      loaders.push(obj)
     }
 
     if (obj = plugin.hooks) {
       Object.keys(obj).map(function (key) {
         hooks[key].push(obj[key])
       })
+    if (obj = plugin.onLoad) {
+      emitter.on('load', obj)
     }
   }
 
@@ -46,9 +45,7 @@ export default function (app) {
 
     render(model, view)
 
-    loaders.map(function (cb) {
-      cb(model, actions, emitter)
-    })
+    emitter.emit('load', model, actions, emitter)
   })
 
   function init(container, group, lastName) {

--- a/src/app.js
+++ b/src/app.js
@@ -78,9 +78,7 @@ export default function (app) {
   }
 
   function render(model, view) {
-    emitter.emit('render', model, view, function(response) {
-      view = response
-    })
+    view = emitter.stack('render', model, view)
 
     element = patch(root, element, node, node = view(model, actions))
   }
@@ -322,6 +320,13 @@ export default function (app) {
         var handler = function(cb) { cb.apply(null, args) }
         ;(all[type] || []).map(handler)
         ;(all['*'] || []).map(handler)
+      },
+
+      stack: function(type) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return (all[type] || []).reduce(function(result, handler) {
+          return handler.apply(null, args.concat(result))
+        }, args.pop());
       }
     }
   }

--- a/src/router.js
+++ b/src/router.js
@@ -10,8 +10,8 @@ export default function (app) {
         }
       }
     },
-    beforeRender: function (model, _, done) {
-      done(app.view[model.router.match])
+    beforeRender: function (model, view) {
+      return app.view[model.router.match]
     },
     onLoad: function (_, actions) {
       addEventListener("popstate", function () {

--- a/src/router.js
+++ b/src/router.js
@@ -10,10 +10,8 @@ export default function (app) {
         }
       }
     },
-    hooks: {
-      onRender: function (model) {
-        return app.view[model.router.match]
-      }
+    beforeRender: function (model, _, done) {
+      done(app.view[model.router.match])
     },
     onLoad: function (_, actions) {
       addEventListener("popstate", function () {

--- a/src/router.js
+++ b/src/router.js
@@ -10,13 +10,15 @@ export default function (app) {
         }
       }
     },
-    beforeRender: function (model, view) {
-      return app.view[model.router.match]
-    },
-    onLoad: function (_, actions) {
-      addEventListener("popstate", function () {
-        actions.router.match(location.pathname)
-      })
+    subscriptions: {
+      "render": function (model, view) {
+        return view[model.router.match]
+      },
+      "load": function (_, actions) {
+        addEventListener("popstate", function () {
+          actions.router.match(location.pathname)
+        })
+      }
     }
   }
 

--- a/src/router.js
+++ b/src/router.js
@@ -15,13 +15,11 @@ export default function (app) {
         return app.view[model.router.match]
       }
     },
-    subscriptions: [
-      function (_, actions) {
-        addEventListener("popstate", function () {
-          actions.router.match(location.pathname)
-        })
-      }
-    ]
+    onLoad: function (_, actions) {
+      addEventListener("popstate", function () {
+        actions.router.match(location.pathname)
+      })
+    }
   }
 
   function match(model, data) {


### PR DESCRIPTION
This PR relates to #177, #174, #150, #144.

After an interesting discussing on Slack, I've modified the emitter implementation. Below is a detailed explanation of what have changed since my [last comment](https://github.com/hyperapp/hyperapp/issues/174#issuecomment-291198564) on issue #174.

From the Slack discussion it was clear that `subscriptions` is the best name to group both `events` and `hooks` since @jbucaran wants to avoid having both. The following is a list of all events and hooks emitted by the core of Hyperapp:

```js
subscriptions: {
    '*': (type) => {},                   // Listens to all events/hooks
    'actions': (name, data) => {},       // When any action is called
    'action:save': (data) => {},         // When a specific action is called
    'update': (name) => {},              // When model updates
    'load': (model, actions) => {        // When the core loads right before the first render
        if (model.contacts.length < 1) {
            actions.contacts.addRandom()
        }
    },
    'render': (model, view) => {         // When rendering
        // do something and
        // return a modified view
        return view
    }
}
```

I have integrated [Mitt](https://github.com/developit/mitt) in Hyperapp storing all handlers on the `subscription` object. Mitt methods `on` and `off` have been removed. The only way to register event/hook handlers now is via the `subscriptions` object when initialising the app/plugin.

Also, Mitt is no longer exposed to the app. Instead only actions will receive an `emit` object allowing them to trigger an `event` and/or `hook`:

- **`emit.event` -** is a way to notify that something happened **without** expecting any value to be returned.

```js
actions: {
  router: {
    match: match,
    go: function (_, data, actions, emit) {
      history.pushState({}, "", data)
      actions.router.match(data)
      emit.event('route:update', data)
    }
  }
}
```

- **`emit.hook` -** **expects** a value to be returned allowing the app/plugin to act based on it. Under the hood this method uses `Array.reduce` to store the value returned since more than one handler may exist for a given hook. The value that will be returned from the hook is stored on the **last argument** allowing the app/plugin to change or replace this value.

```js
function render(model, view) {
  view = emit.hook("render", model, view)

  element = patch(root, element, node, node = view(model, actions))
}
```

In this example from the core, any handler that subscribes to the `render` hook will be able to change or completely replace the `view`, which will be returned since it's the last argument. The router subscribes to the `render` hook:

```js
subscriptions: {
  "render": function (model, view) {
    return view[model.router.match]
  }
}
```

`onLoad` is now `load` and must defined inside `subscribers`. It also no longer receives the `emitter` as I first proposed.

`onRender` is now `render` for short.

These changes maintain the flexibility brought by an event emitter while limiting its use to avoid undesired side effects.

Prefixing core events/hooks and encouraging plugin authors to do the same is a good idea, keep that mind.