### PR TITLE
Not mandatory to concat positional Number/String nodes.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -105,11 +105,11 @@ export default function (app) {
         element.appendChild(createElementFrom(node.children[i++], isSVG))
       }
 
-      for (var name in node.data) {
-        if (name === "onCreate") {
-          node.data[name](element)
+      for (var i in node.data) {
+        if (i === "onCreate") {
+          node.data[i](element)
         } else {
-          setElementData(element, name, node.data[name])
+          setElementData(element, i, node.data[i])
         }
       }
     }
@@ -277,4 +277,3 @@ export default function (app) {
     return element
   }
 }
-

--- a/src/h.js
+++ b/src/h.js
@@ -1,37 +1,22 @@
 export default function (tag, data) {
   var node
-  var canConcat
-  var oldCanConcat
-
   var stack = []
   var children = []
 
   for (var i = arguments.length; i-- > 2;) {
-    stack.push(arguments[i])
+    stack[stack.length] = arguments[i]
   }
 
   while (stack.length) {
     if (Array.isArray(node = stack.pop())) {
-      i = node.length
-
-      while (i--) {
-        stack.push(node[i])
+      for (var i = node.length; i--;) {
+        stack[stack.length] = node[i]
       }
     } else if (node != null && node !== true && node !== false) {
-      i = children.length
-
       if (typeof node === "number") {
         node = node + ""
       }
-
-      canConcat = typeof node === "string"
-
-      if (canConcat && oldCanConcat) {
-        children[i - 1] += node
-      } else {
-        children[i] = node
-        oldCanConcat = canConcat
-      }
+      children[children.length] = node
     }
   }
 
@@ -43,3 +28,4 @@ export default function (tag, data) {
     }
     : tag(data, children)
 }
+

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -28,21 +28,13 @@ test("vnode with a single child", () => {
   })
 })
 
-test("concatenate String/Number children", () => {
+test("positional String/Number children", () => {
   expect(
     h("div", {}, "foo", "bar", "baz")
   ).toEqual({
     tag: "div",
     data: {},
-    children: ["foobarbaz"]
-  })
-
-  expect(
-    h("div", {}, ["foo", "bar", "baz"])
-  ).toEqual({
-    tag: "div",
-    data: {},
-    children: ["foobarbaz"]
+    children: ["foo", "bar", "baz"]
   })
 
   expect(
@@ -50,7 +42,7 @@ test("concatenate String/Number children", () => {
   ).toEqual({
     tag: "div",
     data: {},
-    children: ["1foo2baz3"]
+    children: ["1", "foo", "2", "baz", "3"]
   })
 
   expect(
@@ -62,7 +54,7 @@ test("concatenate String/Number children", () => {
       tag: "div",
       data: {},
       children: ["bar"]
-    }, "bazquux"]
+    }, "baz", "quux"]
   })
 })
 
@@ -127,3 +119,4 @@ test("components", () => {
     }]
   })
 })
+


### PR DESCRIPTION
@ngryman @selfup @dodekeract 

The idea here is to remove the code that concatenates contiguous Number/String nodes. 

```jsx
<div>
    {"string"}
    {"or"}
    {1}
    {"another string"}
</div>
```

Before, h would generate a node with a single child  `"stringor1another string"`, now it generates a node with 4 children, one for each string or number. This is not the same as generating 4 nodes, that doesn't happen.

It may seem like this was a good thing to have, but:

* Such scenario, like in the markup posted above is unlikely.
* Benchmark results were similar (slightly faster without the code actually).
* We can shave more bytes off the bundle for no cost.