### PR TITLE
Optimize h

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -4,7 +4,7 @@ function addChild(children, val) {
       children.push(val[j])
     }
   }
-  else if (val && val !== true) {
+  else if (val != null && val !== true && val !== false) {
     if (typeof val === 'number') {
       val = val + ''
     }

--- a/src/h.js
+++ b/src/h.js
@@ -5,10 +5,7 @@ function addChild(children, val) {
     }
   }
   else if (val != null && val !== true && val !== false) {
-    if (typeof val === 'number') {
-      val = val + ''
-    }
-    children.push(val)
+    children.push(typeof val === 'number' ? val + '' : val)
   }
 }
 
@@ -21,11 +18,9 @@ export default function(tag, data, values) {
     }
   }
   else {
-    addChild(children, values)
-  }
-
-  for (var i = 3; i < arguments.length; i++) {
-    addChild(children, arguments[i])
+    for (var i = 2; i < arguments.length; i++) {
+      addChild(children, arguments[i])
+    }
   }
 
   return typeof tag === "string"

--- a/src/h.js
+++ b/src/h.js
@@ -1,10 +1,12 @@
 function addChild(children, val) {
+  if (val == null || typeof val === 'boolean') return
+
   if (Array.isArray(val)) {
     for (var j = 0; j < val.length; j++) {
       children.push(val[j])
     }
   }
-  else if (val != null && val !== true && val !== false) {
+  else {
     children.push(typeof val === 'number' ? val + '' : val)
   }
 }
@@ -12,14 +14,16 @@ function addChild(children, val) {
 export default function(tag, data, values) {
   var children = []
 
-  if (Array.isArray(values)) {
-    for (var i = 0; i < values.length; i++) {
-      addChild(children, values[i])
+  if (arguments.length > 2) {
+    if (Array.isArray(values)) {
+      for (var i = 0; i < values.length; i++) {
+        addChild(children, values[i])
+      }
     }
-  }
-  else {
-    for (var i = 2; i < arguments.length; i++) {
-      addChild(children, arguments[i])
+    else {
+      for (var i = 2; i < arguments.length; i++) {
+        addChild(children, arguments[i])
+      }
     }
   }
 

--- a/src/h.js
+++ b/src/h.js
@@ -1,19 +1,31 @@
-export default function(tag, data) {
+function addChild(children, val) {
+  if (Array.isArray(val)) {
+    for (var j = 0; j < val.length; j++) {
+      children.push(val[j])
+    }
+  }
+  else if (val && val !== true) {
+    if (typeof val === 'number') {
+      val = val + ''
+    }
+    children.push(val)
+  }
+}
+
+export default function(tag, data, values) {
   var children = []
 
-  for (var i = 2; i < arguments.length; i++) {
-    var val = arguments[i]
-    if (Array.isArray(val)) {
-      for (var j = 0; j < val.length; j++) {
-        children.push(val[j])
-      }
+  if (Array.isArray(values)) {
+    for (var i = 0; i < values.length; i++) {
+      addChild(children, values[i])
     }
-    else if (val && val !== true) {
-      if (typeof val === 'number') {
-        val = val + ''
-      }
-      children.push(val)
-    }
+  }
+  else {
+    addChild(children, values)
+  }
+
+  for (var i = 3; i < arguments.length; i++) {
+    addChild(children, arguments[i])
   }
 
   return typeof tag === "string"

--- a/src/h.js
+++ b/src/h.js
@@ -1,22 +1,18 @@
 export default function(tag, data) {
-  var node
-  var stack = []
   var children = []
 
-  for (var i = arguments.length; i-- > 2; ) {
-    stack[stack.length] = arguments[i]
-  }
-
-  while (stack.length) {
-    if (Array.isArray((node = stack.pop()))) {
-      for (var i = node.length; i--; ) {
-        stack[stack.length] = node[i]
+  for (var i = 2; i < arguments.length; i++) {
+    var val = arguments[i]
+    if (Array.isArray(val)) {
+      for (var j = 0; j < val.length; j++) {
+        children.push(val[j])
       }
-    } else if (node != null && node !== true && node !== false) {
-      if (typeof node === "number") {
-        node = node + ""
+    }
+    else if (val && val !== true) {
+      if (typeof val === 'number') {
+        val = val + ''
       }
-      children[children.length] = node
+      children.push(val)
     }
   }
 

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -15,6 +15,12 @@ test("vnode with a single child", () => {
     children: ["foo"]
   })
 
+  expect(h("div", {}, [["foo"]])).toEqual({
+    tag: "div",
+    data: {},
+    children: ["foo"]
+  })
+
   expect(h("div", {}, "foo")).toEqual({
     tag: "div",
     data: {},


### PR DESCRIPTION
Let's start from this implementation which passes the current tests.

Just to have an idea, here are the benchs:

**Before**
```sh
NANOBENCH version 2
> node

# vnode with no child 1M times
ok ~315 ms (0 s + 315373353 ns)

# vnode with a single child 1M times
ok ~1.35 s (1 s + 353013098 ns)

# vnode with a single array child 1M times
ok ~1.66 s (1 s + 657042054 ns)

all benchmarks completed
ok ~3.33 s (3 s + 325428505 ns)
```

**After**
```sh
NANOBENCH version 2
> node

# vnode with no child 1M times
ok ~287 ms (0 s + 287287753 ns)

# vnode with a single child 1M times
ok ~692 ms (0 s + 692102600 ns)

# vnode with a single array child 1M times
ok ~822 ms (0 s + 822467710 ns)

all benchmarks completed
ok ~1.8 s (1 s + 801858063 ns)
```