### PR TITLE
Fix case-sensitive attributes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -130,7 +130,7 @@ export default function(app) {
       }
     } else {
       try {
-        element[name] = value
+        element[attr] = value
       } catch (_) {}
 
       if (typeof value !== "function") {

--- a/src/app.js
+++ b/src/app.js
@@ -122,8 +122,9 @@ export default function(app) {
   }
 
   function setElementData(element, name, value, oldValue) {
-    if (name === "key") {
-    } else if ((name = name.toLowerCase()) === "style") {
+    var attr = name.toLowerCase();
+    if (attr === "key") {
+    } else if (attr === "style") {
       for (var i in merge(oldValue, (value = value || {}))) {
         element.style[i] = value[i] || ""
       }

--- a/src/app.js
+++ b/src/app.js
@@ -122,15 +122,14 @@ export default function(app) {
   }
 
   function setElementData(element, name, value, oldValue) {
-    var attr = name.toLowerCase();
-    if (attr === "key") {
-    } else if (attr === "style") {
+    if (name === "key") {
+    } else if (name === "style") {
       for (var i in merge(oldValue, (value = value || {}))) {
         element.style[i] = value[i] || ""
       }
     } else {
       try {
-        element[attr] = value
+        element[name.toLowerCase()] = value
       } catch (_) {}
 
       if (typeof value !== "function") {

--- a/test/vdom.test.js
+++ b/test/vdom.test.js
@@ -395,7 +395,7 @@ test("svg", () => {
 
   const svg = document.getElementById("bar")
   expect(svg.namespaceURI).toBe(SVG_NS)
-  expect(svg.viewBox).toBe('0 0 10 10')
+  expect(svg.getAttribute('viewBox')).toBe('0 0 10 10')
   expectChildren(svg)
 
   function expectChildren(svgElement) {

--- a/test/vdom.test.js
+++ b/test/vdom.test.js
@@ -374,7 +374,7 @@ test("svg", () => {
     view: _ =>
       h("div", {}, [
         h("p", { id: "foo" }, "foo"),
-        h("svg", { id: "bar" }, [
+        h("svg", { id: "bar", viewBox: "0 0 10 10" }, [
           h("quux", {}, [
             h("beep", {}, [h("ping", {}), h("pong", {})]),
             h("bop", {}),
@@ -395,6 +395,7 @@ test("svg", () => {
 
   const svg = document.getElementById("bar")
   expect(svg.namespaceURI).toBe(SVG_NS)
+  expect(svg.viewBox).toBe('0 0 10 10')
   expectChildren(svg)
 
   function expectChildren(svgElement) {


### PR DESCRIPTION
Attributes were always converted to lowercase which breaks case-sensitive attributes like `viewBox` for most browsers.

Example: http://codepen.io/anon/pen/VbvGwZ?editors=0010 (the circle should fill the entire viewport)