### PR TITLE
[Fix] Strange bug where `node.data` isn't set within the `removeElement` method.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -162,7 +162,7 @@ export default function(app) {
   }
 
   function removeElement(parent, element, node) {
-    if (node.data.onRemove) {
+    if (node.data && node.data.onRemove) {
       node.data.onRemove(element)
     }
     parent.removeChild(element)


### PR DESCRIPTION
I have a working example where I'm using jsx through babel and doing some odd filtering on that data. Without investigating why the `node.data` isn't set, I've just added that equality in there to make it work. 