### PR TITLE
Add test for when plain-string vnodes are removed

### DIFF
--- a/test/vdom.test.js
+++ b/test/vdom.test.js
@@ -111,6 +111,19 @@ test("insert children on top", () => {
   ])
 })
 
+test("remove text node", () => {
+  TreeTest([
+    {
+      tree: h("main", {}, [h("div", {}, ["foo"]), "bar"]),
+      html: `<main><div>foo</div>bar</main>`
+    },
+    {
+      tree: h("main", {}, [h("div", {}, ["foo"])]),
+      html: `<main><div>foo</div></main>`
+    }
+  ])
+})
+
 test("replace keyed", () => {
   TreeTest([
     {


### PR DESCRIPTION
This test breaks the suite because there is currently a bug in hyperapp, that occurs when textnodes are removed, where we check for `node.data.onRemove` without knowing for sure that `node.data` exists (which it doesn't, if node is just a plain string). Causes a TypeError to be thrown. 
