### PR TITLE
Make router deterministic

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -25,23 +25,29 @@ export default function(app) {
         }
       },
       render: function(state, actions, view) {
-        return view[state.router.match]
+        for (var i = 0, len = view.length; i < len; i++) {
+          var route = view[i]
+          if (route.path === state.router.match) {
+            return route.view
+          }
+        }
       }
     }
   }
 
-  function match(data) {
+  function match(path) {
     var match
     var params = {}
 
-    for (var route in app.view) {
+    for (var i = 0, len = app.view.length; i < len; i++) {
+      var routePath = app.view[i].path
       var keys = []
 
-      if (!match && route !== "*") {
-        data.replace(
+      if (!match && routePath !== "*") {
+        path.replace(
           RegExp(
             "^" +
-              route
+              routePath
                 .replace(/\//g, "\\/")
                 .replace(/:([\w]+)/g, function(_, key) {
                   keys.push(key)
@@ -54,7 +60,7 @@ export default function(app) {
             for (var i = 1; i < arguments.length - 2; ) {
               params[keys.shift()] = arguments[i++]
             }
-            match = route
+            match = routePath
           }
         )
       }

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -13,9 +13,9 @@ beforeEach(() => {
 
 test("/", () => {
   app({
-    view: {
-      "/": state => h("div", {}, "foo")
-    },
+    view: [
+      { path: "/", view: state => h("div", {}, "foo")}
+    ],
     plugins: [Router]
   })
 
@@ -27,9 +27,9 @@ test("/", () => {
 
 test("*", () => {
   app({
-    view: {
-      "*": state => h("div", {}, "foo")
-    },
+    view: [
+      { path: "*", view: state => h("div", {}, "foo") }
+    ],
     plugins: [Router],
     events: {
       loaded: (state, actions) => {
@@ -59,9 +59,9 @@ test("routes", () => {
   window.location.pathname = "/foo/bar/baz"
 
   app({
-    view: {
-      "/foo/bar/baz": state => h("div", {}, "foo", "bar", "baz")
-    },
+    view: [
+      { path: "/foo/bar/baz", view: state => h("div", {}, "foo", "bar", "baz") }
+    ],
     plugins: [Router]
   })
 
@@ -76,8 +76,9 @@ test("route params", () => {
   window.location.pathname = "/be_ep/bOp/b00p"
 
   app({
-    view: {
-      "/:foo/:bar/:baz": state =>
+    view: [{
+      path: "/:foo/:bar/:baz",
+      view: state =>
         h(
           "ul",
           {},
@@ -85,7 +86,7 @@ test("route params", () => {
             h("li", {}, `${key}:${state.router.params[key]}`)
           )
         )
-    },
+    }],
     plugins: [Router]
   })
 
@@ -102,8 +103,9 @@ test("route params separated by a dash", () => {
   window.location.pathname = "/beep-bop-boop"
 
   app({
-    view: {
-      "/:foo-:bar-:baz": state =>
+    view: [{
+      path: "/:foo-:bar-:baz",
+      view: state =>
         h(
           "ul",
           {},
@@ -111,7 +113,7 @@ test("route params separated by a dash", () => {
             h("li", {}, `${key}:${state.router.params[key]}`)
           )
         )
-    },
+    }],
     plugins: [Router]
   })
 
@@ -128,9 +130,10 @@ test("routes with dashes into a single param key", () => {
   window.location.pathname = "/beep-bop-boop"
 
   app({
-    view: {
-      "/:foo": state => h("div", {}, state.router.params.foo)
-    },
+    view: [{
+      path: "/:foo",
+      view: state => h("div", {}, state.router.params.foo)
+    }],
     plugins: [Router]
   })
 
@@ -143,10 +146,13 @@ test("routes with dashes into a single param key", () => {
 
 test("popstate", () => {
   app({
-    view: {
-      "/": state => "",
-      "/foo": state => h("div", {}, "foo")
-    },
+    view: [{
+      path: "/",
+      view: state => "",
+    }, {
+      path: "/foo",
+      view: state => h("div", {}, "foo")
+    }],
     plugins: [Router]
   })
 
@@ -168,12 +174,12 @@ test("go", () => {
     expect(url).toMatch(/^\/(foo|bar|baz)$/)
 
   app({
-    view: {
-      "/": state => "",
-      "/foo": state => h("div", {}, "foo"),
-      "/bar": state => h("div", {}, "bar"),
-      "/baz": state => h("div", {}, "baz")
-    },
+    view: [
+      { path: "/", view: state => "" },
+      { path: "/foo", view: state => h("div", {}, "foo") },
+      { path: "/bar", view: state => h("div", {}, "bar") },
+      { path: "/baz", view: state => h("div", {}, "baz") }
+    ],
     plugins: [Router],
     events: {
       loaded: (state, actions) => {


### PR DESCRIPTION
Using route paths as keys is not a reliable way of describing routes if you later want determinstic server side rendering + client side rehydration or fallthroughs.

Therefore i changed it to a object[] with the objects describing the route:

```js
... view: [{ path: "/:foo", view: state => h("div", {}, state.router.params.foo) }]
```

I changed the tests and docs too. Maybe i missed something or you want to change the docs further. I am not a good writer ;) Review welcome.

FYI: Objects are an unordered collection of properties. The order is purely accidental by your javascript engine doing it's optimizations. If you create a similar object with additional keys you can see what happens.
