### PR TITLE
Fixes internal routing of URLs with query strings

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,7 @@ export default function(app) {
         },
         go: function(state, actions, data) {
           history.pushState({}, "", data)
-          actions.router.match(data)
+          actions.router.match(data.split('?')[0])
         }
       }
     },


### PR DESCRIPTION
```
app(
  view: {
    '/:a/:b': _ => h('button', { onclick: a.navigate }, 'Click Me')
  },
  actions: {
     navigate: (s,a,d) => a.router.go('/other/path?query=1')
  },
  plugins: [Router],
)
```

Given the above app being served from `localhost` (with history-api-fallback behavior). If you were to visit the URL `http://localhost:8080/some/path?query=0` everything would work as expected:

- The router would match `/:a/:b` from `location.pathname` on startup and render the view.

You would be able to see a button. Clicking on the button fires `a.router.go` which gets passed a URL in the same form as the one matched on startup.. this time:

- No view is rendered because no match was found.

This is because when the page loads `router.match` gets passed the `pathname` part of the current URL (which evaluates to `/some/path`) whereas `router.go` tries to match the string it is passed without parsing out the `pathname` part (`/other/path?query=1` instead of `/other/path`).

This PR is trying to ensure only the `pathname` part of a URL passed to `router.go` gets passed to `router.match` so that you can internal route to URLs with query parameters.

