### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Logs
 *.log*
 yarn.lock
+package-lock.json
 
 # Misc
 sandbox


### PR DESCRIPTION
Since `yarn.lock` is ignored already, and now npm 5.0 creates a `package-lock.json` that functions in a similar way.