### PR TITLE
Docs:  Fix onremove lifecycle example

### DIFF
--- a/docs/lifecycle-events.md
+++ b/docs/lifecycle-events.md
@@ -25,7 +25,9 @@ Fired before the element is removed from the DOM.
 Note that when using this event you are responsible for removing the element yourself.
 
 ```js
-element.parent.removeChild(element)
+if (element.parentNode) {
+  element.parentNode.removeChild(element);
+}
 ```
 
 ## Example


### PR DESCRIPTION
`element.parent` does not exist.

Copied example from: 
https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild