### PR TITLE
Add `.` to the allowed characters in params

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -45,7 +45,7 @@ export default function(app) {
                 .replace(/\//g, "\\/")
                 .replace(/:([\w]+)/g, function(_, key) {
                   keys.push(key)
-                  return "([-\\.\\w]+)"
+                  return "([-\\w.~!$&'()*+,;=:@]+)"
                 }) +
               "/?$",
             "g"

--- a/src/router.js
+++ b/src/router.js
@@ -45,7 +45,7 @@ export default function(app) {
                 .replace(/\//g, "\\/")
                 .replace(/:([\w]+)/g, function(_, key) {
                   keys.push(key)
-                  return "([-\\w.~!$&'()*+,;=:@]+)"
+                  return "([-\\.\\w]+)"
                 }) +
               "/?$",
             "g"

--- a/src/router.js
+++ b/src/router.js
@@ -45,7 +45,7 @@ export default function(app) {
                 .replace(/\//g, "\\/")
                 .replace(/:([\w]+)/g, function(_, key) {
                   keys.push(key)
-                  return "([-\\w]+)"
+                  return "([-\\.\\w]+)"
                 }) +
               "/?$",
             "g"

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -124,6 +124,32 @@ test("route params separated by a dash", () => {
   `
 })
 
+test("route params including a dot", () => {
+  window.location.pathname = "/beep/bop.bop/boop"
+
+  app({
+    view: {
+      "/:foo/:bar/:baz": state =>
+        h(
+          "ul",
+          {},
+          Object.keys(state.router.params).map(key =>
+            h("li", {}, `${key}:${state.router.params[key]}`)
+          )
+        )
+    },
+    plugins: [Router]
+  })
+
+  expectHTMLToBe`
+    <ul>
+			<li>foo:beep</li>
+      <li>bar:bop.bop</li>
+      <li>baz:boop</li>
+    </ul>
+  `
+})
+
 test("routes with dashes into a single param key", () => {
   window.location.pathname = "/beep-bop-boop"
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -124,12 +124,12 @@ test("route params separated by a dash", () => {
   `
 })
 
-test("route params including a dot", () => {
-  window.location.pathname = "/beep/bop.bop/boop"
+test("route params including special characters", () => {
+  window.location.pathname = "/be.-ep~!/$&bo'/(o*+o,;=:@p)/bop"
 
   app({
     view: {
-      "/:foo/:bar/:baz": state =>
+      "/:foo/:bar/:baz/:qux": state =>
         h(
           "ul",
           {},
@@ -143,9 +143,10 @@ test("route params including a dot", () => {
 
   expectHTMLToBe`
     <ul>
-			<li>foo:beep</li>
-      <li>bar:bop.bop</li>
-      <li>baz:boop</li>
+      <li>foo:be.-ep~!</li>
+      <li>bar:$&amp;bo'</li>
+      <li>baz:(o*+o,;=:@p)</li>
+      <li>qux:bop</li>
     </ul>
   `
 })

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -124,12 +124,12 @@ test("route params separated by a dash", () => {
   `
 })
 
-test("route params including special characters", () => {
-  window.location.pathname = "/be.-ep~!/$&bo'/(o*+o,;=:@p)/bop"
+test("route params including a dot", () => {
+  window.location.pathname = "/beep/bop.bop/boop"
 
   app({
     view: {
-      "/:foo/:bar/:baz/:qux": state =>
+      "/:foo/:bar/:baz": state =>
         h(
           "ul",
           {},
@@ -143,10 +143,9 @@ test("route params including special characters", () => {
 
   expectHTMLToBe`
     <ul>
-      <li>foo:be.-ep~!</li>
-      <li>bar:$&amp;bo'</li>
-      <li>baz:(o*+o,;=:@p)</li>
-      <li>qux:bop</li>
+			<li>foo:beep</li>
+      <li>bar:bop.bop</li>
+      <li>baz:boop</li>
     </ul>
   `
 })


### PR DESCRIPTION
I needed to capture dots in params, so I added them. 

Maybe we can talk about what hyperapp allows in params?