### PR TITLE
Make router deterministic.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ Type: ([tag](#h-tag), [data](#h-data), [children](#h-children)): [vnode]
 
 * <a name="h-tag"></a>tag: string | ([props](#h-data), [children](#h-children)): [vnode]
 * <a name="h-data"></a>data: {}
-* <a name="h-children"></a>children: string | [vnode]\[\]
+* <a name="h-children"></a>children: string | Array\<[vnode]\>
 
 ## app
 
@@ -54,13 +54,13 @@ Type: ([state](#state), [actions](#actions), [data](#actions-data), [emit](#emit
 ### events
 #### loaded
 
-Type: ([state](#state), [actions](#actions), _, [emit](#emit)) | [events](#loaded)\[\]
+Type: ([state](#state), [actions](#actions), _, [emit](#emit)) | Array\<[events](#loaded)\>
 
 Fired after the view is mounted on the DOM.
 
 #### action
 
-Type: ([state](#state), [actions](#actions), [data](#action-data), [emit](#emit)): [data](#action-data) | [action](#action)\[\]
+Type: ([state](#state), [actions](#actions), [data](#action-data), [emit](#emit)): [data](#action-data) | Array\<[action](#action)\>
 
 * <a name="action-data"></a>data
   * name: string
@@ -70,7 +70,7 @@ Fired before an action is triggered.
 
 #### update
 
-Type: ([state](#state), [actions](#actions), [data](#update-data), [emit](#emit)): [data](#update-data) | [update](#update)\[\]
+Type: ([state](#state), [actions](#actions), [data](#update-data), [emit](#emit)): [data](#update-data) | Array\<[update](#update)\>
 
 * <a name="update-data"></a>data: the updated fragment of the state.
 
@@ -78,13 +78,13 @@ Fired before the state is updated.
 
 #### render
 
-Type: ([state](#state), [actions](#actions), [view](#view), [emit](#emit)): [view](#view) | [render](#render)\[\]
+Type: ([state](#state), [actions](#actions), [view](#view), [emit](#emit)): [view](#view) | Array\<[render](#render)\>
 
 Fired before the view is rendered.
 
 ### plugins
 
-Type: [Plugin](#plugins-plugin)\[\]
+Type: Array\<[Plugin](#plugins-plugin)\>
 
 #### <a name="plugins-plugin"></a>Plugin
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -18,25 +18,27 @@ To add routing to your application, use the Router plugin.
 import { Router } from "hyperapp"
 ```
 
-The router treats the view as an object of key/value pairs where the key is a route, e.g. <samp>*</samp>, <samp>/home</samp> etc., and the value is the corresponding [view](/docs/api.md#view) function.
+The router treats the view as an array of route/view pairs.
 
 ```jsx
 app({
-  view: {
-    "*": state => <h1>404</h1>,
-    "/": state => <h1>Hi.</h1>
-  },
+  view: [
+    ["/", state => <h1>Hi.</h1>]
+    ["*", state => <h1>404</h1>],
+  ],
   plugins: [Router]
 })
 ```
 
-When the page loads or the browser fires a [popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate) event, the view whose key/route matches [location.pathname](https://developer.mozilla.org/en-US/docs/Web/API/Location) will be rendered. If there is no match, <samp>*</samp> is used as a fallback.
+When the page loads or the browser fires a [popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate) event, the first route that matches [location.pathname](https://developer.mozilla.org/en-US/docs/Web/API/Location) will be rendered.
+
+Routes are matched in the order in which they are declared. To use the wildcard <samp>*</samp> correctly, it must be declared last.
 
 |route                    | location.pathname    |
 |-------------------------|-----------------------------------|
-| <samp>*</samp>          | Match if no other route matches.
 | <samp>/</samp>          | <samp>/</samp>
 | <samp>/:foo</samp>      | Match <samp>[A-Za-z0-9]+</samp>. See [params](#params).
+| <samp>*</samp>          | Match anything.
 
 To navigate to a different route use [actions.router.go](#go).
 
@@ -51,7 +53,7 @@ The matched route params.
 
 |route                 |location.pathname    |state.router.params  |
 |----------------------|---------------------|---------------------|
-|<samp>/:foo</samp>    |<samp>/hyper</samp>  | { foo: "hyper" }    |
+|<samp>/:foo</samp>    |/hyper               | { foo: "hyper" }    |
 
 #### match
 
@@ -70,7 +72,7 @@ Update [location.pathname](https://developer.mozilla.org/en-US/docs/Web/API/Loca
 ### events
 #### route
 
-Type: ([state](/docs/api.md#state), [actions](/docs/api.md#actions), [data](#events-data), [emit](/docs/api.md#emit)) | [route](#route)\[\]
+Type: ([state](/docs/api.md#state), [actions](/docs/api.md#actions), [data](#events-data), [emit](/docs/api.md#emit)) | Array\<[route](#route)\>
 
 * <a name="events-data"></a>data
   * [params](#params)

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-export default function(app) {
+export default function(app, view) {
   return {
     state: {
       router: match(location.pathname)
@@ -20,48 +20,54 @@ export default function(app) {
       loaded: function(state, actions) {
         match()
         addEventListener("popstate", match)
+
         function match() {
           actions.router.match(location.pathname)
         }
       },
-      render: function(state, actions, view) {
-        return view[state.router.match]
+      render: function() {
+        return view
       }
     }
   }
 
   function match(data) {
-    var match
-    var params = {}
-
-    for (var route in app.view) {
+    for (
+      var match, params = {}, i = 0, len = app.view.length;
+      i < len;
+      i++
+    ) {
+      var route = app.view[i][0]
       var keys = []
 
-      if (!match && route !== "*") {
+      if (!match) {
         data.replace(
           RegExp(
-            "^" +
-              route
-                .replace(/\//g, "\\/")
-                .replace(/:([\w]+)/g, function(_, key) {
-                  keys.push(key)
-                  return "([-\\.\\w]+)"
-                }) +
-              "/?$",
+            route === "*"
+              ? "." + route
+              : "^" +
+                  route
+                    .replace(/\//g, "\\/")
+                    .replace(/:([\w]+)/g, function(_, key) {
+                      keys.push(key)
+                      return "([-\\.\\w]+)"
+                    }) +
+                  "/?$",
             "g"
           ),
           function() {
-            for (var i = 1; i < arguments.length - 2; ) {
-              params[keys.shift()] = arguments[i++]
+            for (var j = 1; j < arguments.length - 2; ) {
+              params[keys.shift()] = arguments[j++]
             }
             match = route
+            view = app.view[i][1]
           }
         )
       }
     }
 
     return {
-      match: match || "*",
+      match: match,
       params: params
     }
   }

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -13,9 +13,7 @@ beforeEach(() => {
 
 test("/", () => {
   app({
-    view: {
-      "/": state => h("div", {}, "foo")
-    },
+    view: [["/", state => h("div", {}, "foo")]],
     plugins: [Router]
   })
 
@@ -27,9 +25,7 @@ test("/", () => {
 
 test("*", () => {
   app({
-    view: {
-      "*": state => h("div", {}, "foo")
-    },
+    view: [["*", state => h("div", {}, "foo")]],
     plugins: [Router],
     events: {
       loaded: (state, actions) => {
@@ -59,9 +55,9 @@ test("routes", () => {
   window.location.pathname = "/foo/bar/baz"
 
   app({
-    view: {
-      "/foo/bar/baz": state => h("div", {}, "foo", "bar", "baz")
-    },
+    view: [
+      ["/foo/bar/baz", state => h("div", {}, "foo", "bar", "baz")]
+    ],
     plugins: [Router]
   })
 
@@ -76,16 +72,19 @@ test("route params", () => {
   window.location.pathname = "/be_ep/bOp/b00p"
 
   app({
-    view: {
-      "/:foo/:bar/:baz": state =>
-        h(
-          "ul",
-          {},
-          Object.keys(state.router.params).map(key =>
-            h("li", {}, `${key}:${state.router.params[key]}`)
+    view: [
+      [
+        "/:foo/:bar/:baz",
+        state =>
+          h(
+            "ul",
+            {},
+            Object.keys(state.router.params).map(key =>
+              h("li", {}, `${key}:${state.router.params[key]}`)
+            )
           )
-        )
-    },
+      ]
+    ],
     plugins: [Router]
   })
 
@@ -102,16 +101,19 @@ test("route params separated by a dash", () => {
   window.location.pathname = "/beep-bop-boop"
 
   app({
-    view: {
-      "/:foo-:bar-:baz": state =>
-        h(
-          "ul",
-          {},
-          Object.keys(state.router.params).map(key =>
-            h("li", {}, `${key}:${state.router.params[key]}`)
+    view: [
+      [
+        "/:foo-:bar-:baz",
+        state =>
+          h(
+            "ul",
+            {},
+            Object.keys(state.router.params).map(key =>
+              h("li", {}, `${key}:${state.router.params[key]}`)
+            )
           )
-        )
-    },
+      ]
+    ],
     plugins: [Router]
   })
 
@@ -128,16 +130,19 @@ test("route params including a dot", () => {
   window.location.pathname = "/beep/bop.bop/boop"
 
   app({
-    view: {
-      "/:foo/:bar/:baz": state =>
-        h(
-          "ul",
-          {},
-          Object.keys(state.router.params).map(key =>
-            h("li", {}, `${key}:${state.router.params[key]}`)
+    view: [
+      [
+        "/:foo/:bar/:baz",
+        state =>
+          h(
+            "ul",
+            {},
+            Object.keys(state.router.params).map(key =>
+              h("li", {}, `${key}:${state.router.params[key]}`)
+            )
           )
-        )
-    },
+      ]
+    ],
     plugins: [Router]
   })
 
@@ -154,9 +159,7 @@ test("routes with dashes into a single param key", () => {
   window.location.pathname = "/beep-bop-boop"
 
   app({
-    view: {
-      "/:foo": state => h("div", {}, state.router.params.foo)
-    },
+    view: [["/:foo", state => h("div", {}, state.router.params.foo)]],
     plugins: [Router]
   })
 
@@ -169,10 +172,10 @@ test("routes with dashes into a single param key", () => {
 
 test("popstate", () => {
   app({
-    view: {
-      "/": state => "",
-      "/foo": state => h("div", {}, "foo")
-    },
+    view: [
+      ["/", state => ""],
+      ["/foo", state => h("div", {}, "foo")]
+    ],
     plugins: [Router]
   })
 
@@ -194,12 +197,12 @@ test("go", () => {
     expect(url).toMatch(/^\/(foo|bar|baz)$/)
 
   app({
-    view: {
-      "/": state => "",
-      "/foo": state => h("div", {}, "foo"),
-      "/bar": state => h("div", {}, "bar"),
-      "/baz": state => h("div", {}, "baz")
-    },
+    view: [
+      ["/", state => ""],
+      ["/foo", state => h("div", {}, "foo")],
+      ["/bar", state => h("div", {}, "bar")],
+      ["/baz", state => h("div", {}, "baz")]
+    ],
     plugins: [Router],
     events: {
       loaded: (state, actions) => {


### PR DESCRIPTION
See the documentation for details. 

But in a nutshell, this PR changes the behavior and how you use the Router.

- Before
```jsx
app({
  view: {
    "/": defaultView,
    "/dashboard": dashboardView,
    "/billing": billingView
  },
  plugins:[Router]
})
```
- After
```jsx
app({
  view: [
    ["/", defaultView],
    ["/dashboard", dashboardView],
    ["/billing", billingView],
    ["*", errorView]
  ],
  plugins: [Router]
})
```

This is a bit more verbose, but it makes the router route resolution deterministic.

Bundle increase: 13 bytes. 💥 

@igl Ping.
