### PR TITLE
Rename plugins to mixins

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ We assume you have some knowledge of HTML and JavaScript. If you are completely 
     - [View and State](/docs/core.md#view-and-state)
     - [Actions](/docs/core.md#actions)
     - [Events](/docs/core.md#events)
-    - [Plugins](/docs/core.md#plugins)
+    - [Mixins](/docs/core.md#mixins)
 - [Keys](/docs/keys.md)
 - [Custom Tags](/docs/custom-tags.md)
 - [Lifecycle Events](/docs/lifecycle-events.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,7 +76,7 @@ Type: ([state](#state), [actions](#actions), [data](#update-data), [emit](#emit)
 
 Fired before the state is updated.
 
-#### rendero
+#### render
 
 Type: ([state](#state), [actions](#actions), [view](#view), [emit](#emit)): [view](#view) | Array\<[render](#render)\>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@
     * [action](#action)
     * [update](#update)
     * [render](#render)
-  * [props.plugins](#plugins)
+  * [props.mixins](#mixins)
   * [props.root](#root)
 * [emit](#emit)
 
@@ -33,7 +33,7 @@ Type: ([props](#app-props))
   * [view](#view)
   * [actions](#actions)
   * [events](#events)
-  * [plugins](#plugins)
+  * [mixins](#mixins)
   * [root](#root)
 
 ### state
@@ -82,15 +82,16 @@ Type: ([state](#state), [actions](#actions), [view](#view), [emit](#emit)): [vie
 
 Fired before the view is rendered.
 
-### plugins
+### mixins
 
-Type: [Plugin](#plugins-plugin)\[\]
+Type: [Mixin](#mixins-mixin)\[\]
 
-#### <a name="plugins-plugin"></a>Plugin
+#### <a name="mixins-mixin"></a>Mixin
 
-Type: ([props](#app-props)): [props](#plugin-props)
+Type: ([props](#app-props)): [props](#mixin-props)
 
-* <a name="plugin-props"></a>props
+* <a name="mixin-props"></a>props
+  * [mixins](#mixins)
   * [state](#state)
   * [actions](#actions)
   * [events](#events)

--- a/docs/core.md
+++ b/docs/core.md
@@ -316,16 +316,29 @@ app({
   mixins: [Logger]
 })
 ```
-Mixins can also extend other mixins:
+
+Mixins can also compose with other mixins:
 
 ```js
-const A = () => ({
-  state: { foo: 1 }
-}) 
+const Counter = () => ({
+  mixins: [Logger],
+  state: {
+    count: 0
+  },
+  actions: {
+    up: state => { count: state.count + 1 },
+    down: state => { count: state.count + 1 }
+  }
+})
 
-const B = () => ({
-  mixins: [A],
-  state: { bar: 2 }
+app({
+  mixins: [Counter],
+  view: state =>
+    <div class='counter'>
+      <button onclick={actions.up}>+</button>
+      <span>{state.count}</span>
+      <button onclick={actions.down}>-</button
+    </div>
 })
 ```
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -324,7 +324,7 @@ const A = () => ({
 }) 
 
 const B = () => ({
-  mixins: [B],
+  mixins: [A],
   state: { bar: 2 }
 })
 ```

--- a/docs/core.md
+++ b/docs/core.md
@@ -326,18 +326,18 @@ const Counter = () => ({
     count: 0
   },
   actions: {
-    up: state => { count: state.count + 1 },
-    down: state => { count: state.count + 1 }
+    up: state => ({ count: state.count + 1 }),
+    down: state => ({ count: state.count + 1 })
   }
 })
 
 app({
   mixins: [Counter],
   view: state =>
-    <div class='counter'>
+    <div class="counter">
       <button onclick={actions.up}>+</button>
       <span>{state.count}</span>
-      <button onclick={actions.down}>-</button
+      <button onclick={actions.down}>-</button>
     </div>
 })
 ```

--- a/docs/core.md
+++ b/docs/core.md
@@ -8,7 +8,7 @@
     * [Namespaces](#namespaces)
   * [Events](#events)
     * [Custom Events](#custom-events)
-  * [Plugins](#plugins)
+  * [Mixins](#mixins)
 
 ## Virtual Nodes
 
@@ -292,9 +292,9 @@ app({
 })
 ```
 
-### Plugins
+### Mixins
 
-Use [plugins](/docs/api.md#events) to extend your application state, actions and events in a modular fashion.
+Use [mixins](/docs/api.md#mixins) to extend your application state, actions and events in a modular fashion.
 
 ```jsx
 const Logger = () => ({
@@ -313,6 +313,19 @@ app({
   actions: {
     addOne: state => state + 1
   },
-  plugins: [Logger]
+  mixins: [Logger]
 })
 ```
+Mixins can also extend other mixins:
+
+```js
+const A = () => ({
+  state: { foo: 1 }
+}) 
+
+const B = () => ({
+  mixins: [B],
+  state: { bar: 2 }
+})
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Below is an alphabetical list of some of the terms and concepts used throughout 
 
 ##### P
 [state.router.params](/docs/routing.md#params)<br>
-[plugins](/docs/core.md#plugins)<br>
+[mixins](/docs/core.md#mixins)<br>
 [popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate)<br>
 [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)<br>
 [pragma](https://babeljs.io/docs/plugins/transform-react-jsx/#optionspragma)<br>

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -12,7 +12,7 @@
 
 ## Usage
 
-To add routing to your application, use the Router plugin.
+To add routing to your application, use the Router mixin.
 
 ```jsx
 import { Router } from "hyperapp"
@@ -26,7 +26,7 @@ app({
     "*": state => <h1>404</h1>,
     "/": state => <h1>Hi.</h1>
   },
-  plugins: [Router]
+  mixins: [Router]
 })
 ```
 

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,10 @@ export default function(app) {
   for (var i = -1, mixins = app.mixins || []; i < mixins.length; i++) {
     var mixin = mixins[i] ? mixins[i](app) : app
 
+    if (mixin.mixins != null && mixin !== app) {
+      mixins = mixins.concat(mixin.mixins)
+    }
+
     if (mixin.state != null) {
       state = merge(state, mixin.state)
     }

--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,7 @@ export default function(app) {
     Object.keys(mixin.events || []).map(function(key) {
       events[key] = (events[key] || []).concat(mixin.events[key])
     })
-  } 
+  }
 
   if (document.readyState[0] !== "l") {
     load()

--- a/src/app.js
+++ b/src/app.js
@@ -6,19 +6,19 @@ export default function(app) {
   var node
   var element
 
-  for (var i = -1, plugins = app.plugins || []; i < plugins.length; i++) {
-    var plugin = plugins[i] ? plugins[i](app) : app
+  for (var i = -1, mixins = app.mixins || []; i < mixins.length; i++) {
+    var mixin = mixins[i] ? mixins[i](app) : app
 
-    if (plugin.state != null) {
-      state = merge(state, plugin.state)
+    if (mixin.state != null) {
+      state = merge(state, mixin.state)
     }
 
-    init(actions, plugin.actions)
+    init(actions, mixin.actions)
 
-    Object.keys(plugin.events || []).map(function(key) {
-      events[key] = (events[key] || []).concat(plugin.events[key])
+    Object.keys(mixin.events || []).map(function(key) {
+      events[key] = (events[key] || []).concat(mixin.events[key])
     })
-  }
+  } 
 
   if (document.readyState[0] !== "l") {
     load()

--- a/src/router.js
+++ b/src/router.js
@@ -32,11 +32,7 @@ export default function(app, view) {
   }
 
   function match(data) {
-    for (
-      var match, params = {}, i = 0, len = app.view.length;
-      i < len;
-      i++
-    ) {
+    for (var match, params = {}, i = 0, len = app.view.length; i < len; i++) {
       var route = app.view[i][0]
       var keys = []
 

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -4,7 +4,7 @@ import { expectHTMLToBe } from "./util"
 beforeEach(() => (document.body.innerHTML = ""))
 
 test("extend the state", () => {
-  const plugin = app => ({
+  const mixin = app => ({
     state: {
       bar: app.state.foo
     }
@@ -23,7 +23,7 @@ test("extend the state", () => {
         })
       }
     },
-    plugins: [plugin]
+    mixins: [mixin]
   })
 })
 
@@ -47,12 +47,12 @@ test("extend events", () => {
     events: {
       loaded: _ => expect(++count).toBe(1)
     },
-    plugins: [A, B]
+    mixins: [A, B]
   })
 })
 
 test("extend actions", () => {
-  const plugin = app => ({
+  const mixin = app => ({
     actions: {
       foo: {
         bar: {
@@ -84,12 +84,12 @@ test("extend actions", () => {
         `
       }
     },
-    plugins: [plugin]
+    mixins: [mixin]
   })
 })
 
 test("don't overwrite actions in the same namespace", () => {
-  const plugin = app => ({
+  const mixin = app => ({
     actions: {
       foo: {
         bar: {
@@ -122,6 +122,6 @@ test("don't overwrite actions in the same namespace", () => {
         (state, actions) => actions.foo.bar.qux("foo.bar.qux")
       ]
     },
-    plugins: [plugin]
+    mixins: [mixin]
   })
 })

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -125,3 +125,29 @@ test("don't overwrite actions in the same namespace", () => {
     mixins: [mixin]
   })
 })
+
+test('mixin inside of a mixin', () => {
+  const A = () => ({
+    state: {
+      foo: 1
+    }
+  })
+
+  const B = () => ({
+    mixins: [A],
+    state: {
+      bar: 2
+    }
+  })
+
+  app({
+    mixins: [B],
+    view: () => "",
+    events: {
+      loaded: (state) => {
+        expect(state.bar).toBe(2)
+        expect(state.foo).toBe(1)
+      }
+    }
+  })
+})

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -16,7 +16,7 @@ test("/", () => {
     view: {
       "/": state => h("div", {}, "foo")
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -30,7 +30,7 @@ test("*", () => {
     view: {
       "*": state => h("div", {}, "foo")
     },
-    plugins: [Router],
+    mixins: [Router],
     events: {
       loaded: (state, actions) => {
         actions.router.go("/bar")
@@ -62,7 +62,7 @@ test("routes", () => {
     view: {
       "/foo/bar/baz": state => h("div", {}, "foo", "bar", "baz")
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -86,7 +86,7 @@ test("route params", () => {
           )
         )
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -112,7 +112,7 @@ test("route params separated by a dash", () => {
           )
         )
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -138,7 +138,7 @@ test("route params including a dot", () => {
           )
         )
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -157,7 +157,7 @@ test("routes with dashes into a single param key", () => {
     view: {
       "/:foo": state => h("div", {}, state.router.params.foo)
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   expectHTMLToBe`
@@ -173,7 +173,7 @@ test("popstate", () => {
       "/": state => "",
       "/foo": state => h("div", {}, "foo")
     },
-    plugins: [Router]
+    mixins: [Router]
   })
 
   window.location.pathname = "/foo"
@@ -200,7 +200,7 @@ test("go", () => {
       "/bar": state => h("div", {}, "bar"),
       "/baz": state => h("div", {}, "baz")
     },
-    plugins: [Router],
+    mixins: [Router],
     events: {
       loaded: (state, actions) => {
         actions.router.go("/foo")


### PR DESCRIPTION
 - Renames `plugins` to `mixins`
 - Allows mixins to extend mixins
 - Updates documentation