### PR TITLE
Enable embedding self-contained apps in views

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ export default function(app) {
   var actions = {}
   var events = {}
   var node
-  var element
+  var element = app.element
 
   for (var i = -1, mixins = app.mixins || []; i < mixins.length; i++) {
     var mixin = mixins[i] ? mixins[i](app) : app


### PR DESCRIPTION
This allows an app to declare that it wants to be rendered at
a specific position among siblings within it's root, by
declaring the element at that position to the renderer.

The primary motivation for this, is that it is possible to embed
self contained apps inside views, by rendering a "dummy" virtual
node with an oncreate handler that instantiates the embedded app.

Without this change, however, apps embedded like this will be
rendered at the *end* of the list of siblings, because the
renderer does not know any better.

*With* this change, the instantiation of the embedded app can
inform the renderer to render the app in the position of the dummy
vnode