### PR TITLE
Return the state fragment to the caller if the action is a reducer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperapp",
   "description": "1kb JavaScript library for building frontend applications.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "dist/hyperapp.js",
   "jsnext:main": "src/index.js",
   "module": "src/index.js",

--- a/src/app.js
+++ b/src/app.js
@@ -44,11 +44,11 @@ export default function(app) {
             emit
           )
 
-          if (result == null || typeof result.then === "function") {
-            return result
+          if (result != null && typeof result.then !== "function") {
+            render((state = merge(state, emit("update", result))), view)
           }
 
-          render((state = merge(state, emit("update", result))), view)
+          return result
         }
       } else {
         init(namespace[key] || (namespace[key] = {}), action, name)

--- a/src/app.js
+++ b/src/app.js
@@ -6,12 +6,9 @@ export default function(app) {
   var node
   var element
 
-  for (var i = -1, mixins = app.mixins || []; i < mixins.length; i++) {
+  for (var i = -1, mixins = []; i < mixins.length; i++) {
     var mixin = mixins[i] ? mixins[i](app) : app
-
-    if (mixin.mixins != null && mixin !== app) {
-      mixins = mixins.concat(mixin.mixins)
-    }
+    mixins = mixins.concat(mixin.mixins || [])
 
     if (mixin.state != null) {
       state = merge(state, mixin.state)


### PR DESCRIPTION
Now actions.myAction will return whatever the original myAction function returns. Before, this was only true if myAction returned a Promise.

## Example

```jsx
app({
...
  actions: {
    getState: state => state
  }
...
})
```

Diff: 0 bytes.

Fix #242.

