### PR TITLE
WIP suggestion for #238

### DIFF
--- a/poc/index.js
+++ b/poc/index.js
@@ -1,0 +1,32 @@
+// to run this, go to the poc folder and run
+// npm install -g beefy
+// npm install browserify babelify babel-preset-es2015 babel-preset-react
+// beefy index.js -- -t [babelify --presets [react es2015] ]
+
+import { app, h, Provider, connect } from '../src/index.js'
+// import { h, Provider, connect } from './connect.js'
+/** @jsx h */
+console.log(1)
+
+const Controls = connect((props, children) => (
+  <div>
+    <button onclick={props.context.add}>+</button>
+    <button onclick={props.context.sub}>-</button>
+    <p>{props.regularPropsWork}</p>
+  </div>
+))
+
+app({
+  state: 0,
+  view: (state, actions) => (
+    <main>
+      <Provider context={actions} />
+      <h1>{state}</h1>
+      <Controls regularPropsWork="just fine" />
+    </main>
+  ),
+  actions: {
+    add: state => state + 1,
+    sub: state => state - 1
+  }
+})

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,0 +1,32 @@
+import h from './h.js'
+const CONNECTED = Symbol()
+
+// TODO: figure out how to have one context per app instance, not a global one
+const hConnected = (() => {
+  const context = {}
+  return function hProvided (tag, data, ...rest) {
+    if (tag === Provider) {
+      Object.assign(context, data.context)
+    }
+    if (tag.connected === CONNECTED) {
+      data = data || {}
+      data.context = context
+    }
+    return h.call(null, tag, data, ...rest)
+  }
+})()
+
+export {hConnected as h}
+export const Provider = () => null
+
+export function connect (component /*, mapContextToProps TBD by wrapping component */) {
+  component.connected = CONNECTED
+  // probable mapContextToProps implementation, untested
+  // return (props, ...rest) => {
+  //   if(mapContextToProps) {
+  //     props = Object.assign({},props, mapContextToProps(props.context))
+  //   }
+  //   return component(props,...rest)
+  // }
+  return component
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import h from "./h"
+import { h, Provider, connect } from "./connect"
 import app from "./app"
 import Router from "./router"
 
-export { h, app, Router }
+export { h, Provider, connect, app, Router }


### PR DESCRIPTION
I didn't exactly like where #238 was going with components looking like more hperapp apps with separate state and actions.

I've built something that's similar to how redux-react does single source of truth.
Actions would stay on the main app along with the state they're modifying.

The only issue I think has to be fixed before this is viable is finding a better place to put context in. It has to be rooted in the app, but I didn't find the right place yet. It'd probably eliminate the need to have Provider at all. 

see `/poc` for usage example.