### PR TITLE
Adds % char to router.match regex

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -46,7 +46,7 @@ export default function(app, view) {
                     .replace(/\//g, "\\/")
                     .replace(/:([\w]+)/g, function(_, key) {
                       keys.push(key)
-                      return "([-\\.\\w]+)"
+                      return "([-\\.%\\w]+)"
                     }) +
                   "/?$",
             "g"


### PR DESCRIPTION
Currently the router will fail to match `/:search` against `/frontend%20libraries` because the `%` character is not valid according to the regex in _router.match_.

Related https://github.com/hyperapp/hyperapp/pull/230

Fixed by adding `%` to the the regex.