### PR TITLE
Allow messages to be sent to apps

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Type: ([tag](#h-tag), [data](#h-data), [children](#h-children)): [vnode]
 
 ## app
 
-Type: ([props](#app-props))
+Type: ([props](#app-props)): [emit](#emit)
 
 * <a name="app-props"></a> props
   * [state](#state)

--- a/docs/core.md
+++ b/docs/core.md
@@ -9,6 +9,7 @@
   * [Events](#events)
     * [Custom Events](#custom-events)
   * [Mixins](#mixins)
+* [Integration](#integration)
 
 ## Virtual Nodes
 
@@ -315,5 +316,33 @@ app({
   },
   mixins: [Logger]
 })
+```
+
+
+## Integration
+
+The `app(...)` call returns the [emit](/docs/api.md#emit) function, making it possible to trigger [custom events](#custom-events) from outside the [application](#applications) itself. This is useful in situations where your app is a part of a larger system.
+
+```js
+
+const tellApp = app({
+  ...
+  events: {
+    ...
+    'outside:data': (state, actions, newData) => actions.setNewData(newData),
+    ...
+  },
+  actions: {
+    ...
+    setNewData: (state, actions, newData) => ...
+    ...
+  }
+  ...
+})
+
+...
+
+tellApp('outside:data', someNewData)
+
 ```
 

--- a/src/app.js
+++ b/src/app.js
@@ -27,6 +27,8 @@ export function app(app) {
     addEventListener("DOMContentLoaded", load)
   }
 
+  return emit
+
   function init(namespace, children, lastName) {
     Object.keys(children || []).map(function(key) {
       var action = children[key]

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,19 @@
+import { h, app } from "../src"
+import { expectHTMLToBe } from "./util"
+
+beforeEach(() => (document.body.innerHTML = ""))
+
+test("send messages to app", () => {
+  const send = app({
+    view: state => h("div", {}, [state]),
+    state: "",
+    actions: {
+      set: (state, actions, str) => str
+    },
+    events: {
+      "info:set": (state, actions, str) => actions.set(str)
+    }
+  })
+  send("info:set", "testinfo")
+  expectHTMLToBe`<div>testinfo</div>`
+})


### PR DESCRIPTION
We let the `app(...)` call return its emit-function. This allows
external agents to send messages to the app, and the app doesn't
need to know who they are and how they communicate. It only needs
to define its external interface in the `events` property.