### PR TITLE
Add hash router capability to router.js

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,70 +1,99 @@
-export default function(app, view) {
-  return {
-    state: {
-      router: match(location.pathname)
-    },
-    actions: {
-      router: {
-        match: function(state, actions, data, emit) {
-          return {
-            router: emit("route", match(data))
+function Router(getLocation, subscribe, goTo) {
+  return function(app) {
+    return {
+      state: {
+        router: match(app, getLocation())
+      },
+      actions: {
+        router: {
+          match: function(state, actions, data, emit) {
+            return {
+              router: emit("route", match(app, data))
+            }
+          },
+          go: function(state, actions, data) {
+            goTo(data)
+            actions.router.match(data)
           }
-        },
-        go: function(state, actions, data) {
-          history.pushState({}, "", data)
-          actions.router.match(data.split("?")[0])
-        }
-      }
-    },
-    events: {
-      loaded: function(state, actions) {
-        match()
-        addEventListener("popstate", match)
-
-        function match() {
-          actions.router.match(location.pathname)
         }
       },
-      render: function() {
-        return view
-      }
-    }
-  }
+      events: {
+        loaded: function(state, actions) {
+          match()
+          subscribe(match)
 
-  function match(data) {
-    for (var match, params = {}, i = 0, len = app.view.length; i < len; i++) {
-      var route = app.view[i][0]
-      var keys = []
-
-      if (!match) {
-        data.replace(
-          RegExp(
-            route === "*"
-              ? "." + route
-              : "^" +
-                  route
-                    .replace(/\//g, "\\/")
-                    .replace(/:([\w]+)/g, function(_, key) {
-                      keys.push(key)
-                      return "([-\\.%\\w]+)"
-                    }) +
-                  "/?$",
-            "g"
-          ),
-          function() {
-            for (var j = 1; j < arguments.length - 2; ) {
-              params[keys.shift()] = arguments[j++]
-            }
-            match = route
-            view = app.view[i][1]
+          function match() {
+            actions.router.match(getLocation())
           }
-        )
+        },
+        render: function(state) {
+          return state.router.view
+        }
       }
-    }
-
-    return {
-      match: match,
-      params: params
     }
   }
 }
+
+function match(app, data) {
+  var view
+  for (var match, params = {}, i = 0, len = app.view.length; i < len; i++) {
+    var route = app.view[i][0]
+    var keys = []
+
+    if (!match) {
+      data.replace(
+        RegExp(
+          route === "*"
+            ? "." + route
+            : "^" +
+                route
+                  .replace(/\//g, "\\/")
+                  .replace(/:([\w]+)/g, function(_, key) {
+                    keys.push(key)
+                    return "([-\\.%\\w]+)"
+                  }) +
+                "/?$",
+          "g"
+        ),
+        function() {
+          for (var j = 1; j < arguments.length - 2; ) {
+            params[keys.shift()] = arguments[j++]
+          }
+          match = route
+          view = app.view[i][1]
+        }
+      )
+    }
+  }
+
+  return {
+    match: match,
+    params: params,
+    view: view
+  }
+}
+
+var BrowserRouter = Router(
+  function getLocation() {
+    return location.pathname
+  },
+  function subscribe(cb) {
+    addEventListener("popstate", cb)
+  },
+  function goTo(data) {
+    history.pushState({}, "", data)
+  }
+)
+BrowserRouter.Hash = Router(
+  function getLocation() {
+    return (location.hash || "/").replace(/^#/, "")
+  },
+  function subscribe(cb) {
+    addEventListener("hashchange", cb)
+  },
+  function goTo(data) {
+    location.hash = "#" + data
+  }
+)
+
+export default BrowserRouter


### PR DESCRIPTION
Abstract out core routing functionality and construct two routers for export at module load:

* The usual `Router`
* `Router.Hash` that uses hash routing.

The interface for both is equivalent and can be used like the following:

```js
const {app, Router} = hyperapp
app({
  mixins: [Router]
})
// or
app({
  mixins: [Router.Hash]
})
```

The rollup file `hyperapp.js` increases by only 238 bytes with this addition:

```txt
-rw-r--r--  1 me  me   3621 Jun 29 11:39 hyperapp.js (before)
-rw-r--r--  1 me  me   3859 Jun 29 11:39 hyperapp.js (after)
```

Prior work:
* hyperapp/hyperapp/pull/79
* ...