### PR TITLE
Simplify API surface.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,20 +47,20 @@ Type: ([state](#state), [actions](#actions)): [vnode]
 ### actions
 #### <a name="actions-foo"></a>[namespace.]_foo_
 
-Type: ([state](#state), [actions](#actions), [data](#actions-data), [emit](#emit))
+Type: ([state](#state), [actions](#actions), [data](#actions-data))
 
 * <a name="actions-data"></a> data: any
 
 ### events
 #### ready
 
-Type: ([state](#state), [actions](#actions), _, [emit](#emit)) | Array\<[events](#ready)\>
+Type: ([state](#state), [actions](#actions)) | Array\<[events](#ready)\>
 
 Fired after the view is mounted on the DOM.
 
 #### action
 
-Type: ([state](#state), [actions](#actions), [data](#action-data), [emit](#emit)): [data](#action-data) | Array\<[action](#action)\>
+Type: ([state](#state), [actions](#actions), [data](#action-data)): [data](#action-data) | Array\<[action](#action)\>
 
 * <a name="action-data"></a>data
   * name: string
@@ -70,7 +70,7 @@ Fired before an action is triggered.
 
 #### update
 
-Type: ([state](#state), [actions](#actions), [data](#update-data), [emit](#emit)): [data](#update-data) | Array\<[update](#update)\>
+Type: ([state](#state), [actions](#actions), [data](#update-data)): [data](#update-data) | Array\<[update](#update)\>
 
 * <a name="update-data"></a>data: the updated fragment of the state.
 
@@ -78,7 +78,7 @@ Fired before the state is updated.
 
 #### render
 
-Type: ([state](#state), [actions](#actions), [view](#view), [emit](#emit)): [view](#view) | Array\<[render](#render)\>
+Type: ([state](#state), [actions](#actions), [view](#view)): [view](#view) | Array\<[render](#render)\>
 
 Fired before the view is rendered.
 
@@ -88,13 +88,13 @@ Type: Array\<[Mixin](#mixins-mixin)\>
 
 #### <a name="mixins-mixin"></a>Mixin
 
-Type: ([props](#app-props)): [props](#mixin-props)
+Type: ([emit](#emit)): [props](#mixin-props)
 
 * <a name="mixin-props"></a>props
-  * [mixins](#mixins)
   * [state](#state)
   * [actions](#actions)
   * [events](#events)
+  * [mixins](#mixins)
 
 ### root
 

--- a/docs/core.md
+++ b/docs/core.md
@@ -275,15 +275,14 @@ For a practical example see the implementation of the [Router](https://github.co
 
 #### Custom Events
 
-To create custom events, use the [emit(event, data)](/docs/api.md#emit) function. This function is passed as the last argument to actions/events.
+The [app](/docs/api.md#app) call returns the [emit](/docs/api.md#emit) function, making it possible to trigger [custom events](#custom-events).
 
 ```jsx
-app({
-  view: (state, actions) =>
-    <button onclick={actions.fail}>Fail</button>,
+const emit = app({
+  view: (state, { fail }) =>
+    <button onclick={fail}>Fail</button>,
   actions: {
-    fail: (state, actions, data, emit) =>
-      emit("error", "Fail")
+    fail: (state, actions, data) => emit("error", "Fail")
   },
   events: {
     error: (state, actions, error) => {
@@ -291,6 +290,26 @@ app({
     }
   }
 })
+```
+
+Custom events can be useful in situations where your application is a part of a larger system and you want to communicate from the outside.
+
+```js
+const emit = app({
+  state: 0,
+  actions: {
+    setData: (state, actions, data) => data
+  },
+  view: state => <h1>{state}</h1>,
+  events: {
+    "outside:data": (state, actions, data) =>
+      actions.setData(data)
+  }
+})
+
+...
+
+emit("outside:data", 1)
 ```
 
 ### Mixins
@@ -316,33 +335,5 @@ app({
   },
   mixins: [Logger]
 })
-```
-
-
-## Integration
-
-The `app(...)` call returns the [emit](/docs/api.md#emit) function, making it possible to trigger [custom events](#custom-events) from outside the [application](#applications) itself. This is useful in situations where your app is a part of a larger system.
-
-```js
-
-const tellApp = app({
-  ...
-  events: {
-    ...
-    'outside:data': (state, actions, newData) => actions.setNewData(newData),
-    ...
-  },
-  actions: {
-    ...
-    setNewData: (state, actions, newData) => ...
-    ...
-  }
-  ...
-})
-
-...
-
-tellApp('outside:data', someNewData)
-
 ```
 

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ export function app(app) {
   var element
 
   for (var i = -1, mixins = []; i < mixins.length; i++) {
-    var mixin = mixins[i] ? mixins[i](app) : app
+    var mixin = mixins[i] ? mixins[i](emit) : app
     mixins = mixins.concat(mixin.mixins || [])
 
     if (mixin.state != null) {
@@ -23,6 +23,7 @@ export function app(app) {
   }
 
   emit("ready", render(state, view))
+
   return emit
 
   function render(state, view) {
@@ -47,8 +48,7 @@ export function app(app) {
             emit("action", {
               name: name,
               data: data
-            }).data,
-            emit
+            }).data
           )
 
           if (result != null && typeof result.then !== "function") {
@@ -65,7 +65,7 @@ export function app(app) {
 
   function emit(name, data) {
     ;(events[name] || []).map(function(cb) {
-      var result = cb(state, actions, data, emit)
+      var result = cb(state, actions, data)
       if (result != null) {
         data = result
       }

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -87,13 +87,13 @@ test("render", () => {
 })
 
 test("custom event", () => {
-  app({
+  const emit = app({
     view: state => "",
     events: {
-      ready: (state, actions, _, emit) => emit("foo", "foo"),
       foo: (state, actions, data) => expect("foo").toBe(data)
     }
   })
+  emit("foo", "foo")
 })
 
 test("nested action name", () => {

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -4,9 +4,9 @@ import { expectHTMLToBe } from "./util"
 beforeEach(() => (document.body.innerHTML = ""))
 
 test("extend the state", () => {
-  const mixin = app => ({
+  const mixin = () => ({
     state: {
-      bar: app.state.foo
+      bar: true
     }
   })
 


### PR DESCRIPTION
- [x] Don't pass `appOptions` to mixins.
- [x] Don't pass `emit` to events.
- [x] Don't pass `emit` to actions.
- [x] Update docs.
- [x] Pass `emit` as 2nd argument to mixins.
