### PR TITLE
Optimize h

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "module": "src/index.js",
   "license": "MIT",
   "repository": "hyperapp/hyperapp",
-  "files": ["src", "dist"],
+  "files": [
+    "src",
+    "dist"
+  ],
   "author": "Jorge Bucaran",
   "keywords": [
     "hyperapp",
@@ -24,7 +27,9 @@
     "build": "rollup -cm -n hyperapp -f umd -i src/index.js -o dist/hyperapp.js",
     "prepublish": "npm run build",
     "format": "prettier --semi false --write 'src/**/*.js'",
-    "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
+    "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish",
+    "bench": "rollup perf/h.js -f cjs | node",
+    "trace": "rollup perf/h.js -f cjs | node-irhydra"
   },
   "babel": {
     "presets": "es2015"
@@ -35,7 +40,9 @@
     "jest": "^20.0.4",
     "prettier": "~1.5.2",
     "rollup": "^0.43.0",
-    "rollup-plugin-uglify": "^2.0.1"
+    "rollup-plugin-uglify": "^2.0.1",
+    "nanobench": "^2.1.0",
+    "node-irhydra": "^1.0.0"
   },
   "bundlesize": [
     {

--- a/perf/h.js
+++ b/perf/h.js
@@ -1,0 +1,26 @@
+import bench from 'nanobench'
+import { h } from '../src/h'
+
+bench("vnode with no child 1M times", b => {
+  b.start()
+  for (let i = 0; i < 10000000; i++) {
+    h("div", {})
+  }
+  b.end()
+})
+
+bench("vnode with a single child 1M times", b => {
+  b.start()
+  for (let i = 0; i < 10000000; i++) {
+    h("div", {}, ["foo"])
+  }
+  b.end()
+})
+
+bench("vnode with a single array child 1M times", b => {
+  b.start()
+  for (let i = 0; i < 10000000; i++) {
+    h("div", {}, [["foo"]])
+  }
+  b.end()
+})

--- a/src/h.js
+++ b/src/h.js
@@ -1,22 +1,29 @@
-export function h(tag, data) {
-  var node
-  var stack = []
+function addChild(children, val) {
+  if (val == null || typeof val === 'boolean') return
+
+  if (Array.isArray(val)) {
+    for (var j = 0; j < val.length; j++) {
+      children.push(val[j])
+    }
+  }
+  else {
+    children.push(typeof val === 'number' ? val + '' : val)
+  }
+}
+
+export function h(tag, data, values) {
   var children = []
 
-  for (var i = arguments.length; i-- > 2; ) {
-    stack[stack.length] = arguments[i]
-  }
-
-  while (stack.length) {
-    if (Array.isArray((node = stack.pop()))) {
-      for (var i = node.length; i--; ) {
-        stack[stack.length] = node[i]
+  if (arguments.length > 2) {
+    if (Array.isArray(values)) {
+      for (var i = 0; i < values.length; i++) {
+        addChild(children, values[i])
       }
-    } else if (node != null && node !== true && node !== false) {
-      if (typeof node === "number") {
-        node = node + ""
+    }
+    else {
+      for (var i = 2; i < arguments.length; i++) {
+        addChild(children, arguments[i])
       }
-      children[children.length] = node
     }
   }
 

--- a/src/h.js
+++ b/src/h.js
@@ -1,28 +1,18 @@
-function addChild(children, val) {
-  if (val == null || typeof val === 'boolean') return
+var isArray = Array.isArray
 
-  if (Array.isArray(val)) {
-    for (var j = 0; j < val.length; j++) {
-      children.push(val[j])
-    }
-  }
-  else {
-    children.push(typeof val === 'number' ? val + '' : val)
-  }
-}
-
-export function h(tag, data, values) {
+export function createNode(tag, data, values) {
   var children = []
 
-  if (arguments.length > 2) {
-    if (Array.isArray(values)) {
-      for (var i = 0; i < values.length; i++) {
-        addChild(children, values[i])
+  for (var i = 0; i < values.length; i++) {
+    var val = values[i]
+    if (val && val !== true && val !== false) {
+      if (isArray(val)) {
+        for (var j = 0; j < val.length; j++) {
+          children.push(val[j])
+        }
       }
-    }
-    else {
-      for (var i = 2; i < arguments.length; i++) {
-        addChild(children, arguments[i])
+      else {
+        children.push(typeof val === 'number' ? val + '' : val)
       }
     }
   }
@@ -34,4 +24,15 @@ export function h(tag, data, values) {
         children: children
       }
     : tag(data, children)
+}
+
+export function h(tag, data, values) {
+  if (!isArray(values)) {
+    values = []
+    for (var i = 2; i < arguments.length; i++) {
+      values.push(arguments[i])
+    }
+  }
+
+  return createNode(tag, data, values || [])
 }

--- a/src/h.js
+++ b/src/h.js
@@ -5,7 +5,7 @@ export function createNode(tag, data, values) {
 
   for (var i = 0; i < values.length; i++) {
     var val = values[i]
-    if (val && val !== true && val !== false) {
+    if (val && val !== true) {
       if (isArray(val)) {
         for (var j = 0; j < val.length; j++) {
           children.push(val[j])


### PR DESCRIPTION
The child of #187.

**Before**
```sh
NANOBENCH version 2
> node

# vnode with no child 1M times
ok ~319 ms (0 s + 319243686 ns)

# vnode with a single child 1M times
ok ~1.48 s (1 s + 481573267 ns)

# vnode with a single array child 1M times
ok ~1.67 s (1 s + 670888960 ns)

all benchmarks completed
ok ~3.47 s (3 s + 471705913 ns)
```

**After**
```sh
NANOBENCH version 2
> node

# vnode with no child 1M times
ok ~330 ms (0 s + 330196882 ns)

# vnode with a single child 1M times
ok ~954 ms (0 s + 953737873 ns)

# vnode with a single array child 1M times
ok ~990 ms (0 s + 990082693 ns)

all benchmarks completed
ok ~2.27 s (2 s + 274017448 ns)
```

I've committed a small facility to compare perfs, I'll strip them before squashing and merging.

Things to explore:
 - [ ] Better bench use cases. @jbucaran ideas?
 - [ ] Node constructors (https://github.com/hyperapp/hyperapp/pull/187#issuecomment-294316864)
 - [ ] Recycling.

Other `h` out there:
 - **preact**: https://github.com/developit/preact/blob/master/src/h.js
 - **react**: https://github.com/facebook/react/blob/5c6a496d98b80d19d851c2ec3a56d760b7118a50/src/isomorphic/classic/element/ReactElement.js#L180
 - **inferno**: https://github.com/infernojs/inferno/blob/master/packages/inferno-create-element/src/index.ts

Refs:
 - Why 2 for loops: https://github.com/hyperapp/hyperapp/pull/187#issuecomment-294339008