### PR TITLE
basic implementation of node recycling

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ const { h, app } = hyperapp
 
 app({
   state: "Hi.",
-  view: state => h("h1", null, state)
+  view: state => h("h1", {}, state)
 })
 
 </script>
@@ -33,7 +33,7 @@ state: "Hi."
 The view describes the user interface.
 
 ```js
-state => h("h1", null, state) // <h1>Hi.</h1>
+state => h("h1", {}, state) // <h1>Hi.</h1>
 ```
 
 [Hyperx]: /docs/hyperx.md
@@ -44,7 +44,7 @@ To compose the user interface, the [h(tag, data, children)](/docs/api.md#h) util
 ```js
 {
   tag: "h1",
-  data: null,
+  data: {},
   children: ["Hi"]
 }
 ```

--- a/src/app.js
+++ b/src/app.js
@@ -247,6 +247,9 @@ export function app(app) {
           if (null == oldKey) {
             patch(element, oldElement, oldChild, newChild)
             j++
+
+            // causes issues with test: insert children on top
+            //recoverNode(oldChild)
           }
           i++
         } else {
@@ -259,6 +262,15 @@ export function app(app) {
           } else {
             patch(element, oldElement, null, newChild)
           }
+
+          /* causes problems with the following tests:
+            reorder keyed
+            mixed keyed/non-keyed
+            style
+            update element data
+            svg
+          */
+          //recoverNode(reusableChild[1])
 
           j++
           newKeys[newKey] = newChild
@@ -281,6 +293,7 @@ export function app(app) {
           removeElement(element, reusableChild[0], reusableNode)
         }
       }
+      recoverNode(oldNode)
     } else if (node !== oldNode) {
       var i = element
       parent.replaceChild((element = createElement(node)), i)

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+import { getNode, recoverNode } from "./h"
+
 export function app(app) {
   var state = {}
   var actions = {}
@@ -41,13 +43,13 @@ export function app(app) {
   function hydrate(element, map) {
     return element == null
       ? element
-      : {
-          tag: element.tagName,
-          data: {},
-          children: map.call(element.childNodes, function(element) {
+      : getNode(
+          element.tagName,
+          {},
+          map.call(element.childNodes, function(element) {
             hydrate(element, map)
           })
-        }
+        )
   }
 
   function render() {
@@ -265,6 +267,7 @@ export function app(app) {
         var oldKey = getKey(oldChild)
         if (null == oldKey) {
           removeElement(element, oldElements[i], oldChild)
+          recoverNode(oldChild)
         }
         i++
       }
@@ -274,11 +277,13 @@ export function app(app) {
         var reusableNode = reusableChild[1]
         if (!newKeys[reusableNode.data.key]) {
           removeElement(element, reusableChild[0], reusableNode)
+          recoverNode(reusableNode)
         }
       }
     } else if (node !== oldNode) {
       var i = element
       parent.replaceChild((element = createElement(node)), i)
+      recoverNode(oldNode)
     }
 
     return element

--- a/src/app.js
+++ b/src/app.js
@@ -196,6 +196,7 @@ export function app(app) {
     function removeChild() {
       parent.removeChild(element)
     }
+    recoverNode(node)
   }
 
   function patch(parent, element, oldNode, node) {
@@ -267,7 +268,6 @@ export function app(app) {
         var oldKey = getKey(oldChild)
         if (null == oldKey) {
           removeElement(element, oldElements[i], oldChild)
-          recoverNode(oldChild)
         }
         i++
       }
@@ -277,7 +277,6 @@ export function app(app) {
         var reusableNode = reusableChild[1]
         if (!newKeys[reusableNode.data.key]) {
           removeElement(element, reusableChild[0], reusableNode)
-          recoverNode(reusableNode)
         }
       }
     } else if (node !== oldNode) {

--- a/src/app.js
+++ b/src/app.js
@@ -202,7 +202,9 @@ export function app(app) {
   function patch(parent, element, oldNode, node) {
     if (oldNode == null) {
       element = parent.insertBefore(createElement(node), element)
-    } else if (node.tag && node.tag === oldNode.tag) {
+    } else if (typeof node === "string" && typeof oldNode === "string") {
+      element.nodeValue = node
+    }else if (node.tag && node.tag === oldNode.tag) {
       updateElementData(element, oldNode.data, node.data)
 
       var len = node.children.length

--- a/src/h.js
+++ b/src/h.js
@@ -1,4 +1,5 @@
 var nodePool = []
+var nodePoolHead = -1
 
 function reuseNode(node, tag, data, children) {
   node.tag = tag
@@ -8,14 +9,14 @@ function reuseNode(node, tag, data, children) {
 }
 
 export function getNode(tag, data, children) {
-  return nodePool.length > 0 
-    ? reuseNode(nodePool.pop(), tag, data, children)
+  return nodePoolHead > -1
+    ? reuseNode(nodePool[nodePoolHead--], tag, data, children)
     : { tag: tag, data: data, children: children }
 }
 
 export function recoverNode(node) {
   if (typeof node !== "string") {
-    nodePool.push(node)
+    nodePool[++nodePoolHead] = node
   }
 }
 

--- a/src/h.js
+++ b/src/h.js
@@ -8,11 +8,9 @@ function reuseNode(node, tag, data, children) {
 }
 
 export function getNode(tag, data, children) {
-  if (nodePool.length > 0) {
-    return reuseNode(nodePool.pop(), tag, data, children)
-  } else {
-    return { tag: tag, data: data, children: children }
-  }
+  return nodePool.length > 0 
+    ? reuseNode(nodePool.pop(), tag, data, children)
+    : { tag: tag, data: data, children: children }
 }
 
 export function recoverNode(node) {

--- a/src/h.js
+++ b/src/h.js
@@ -1,3 +1,26 @@
+var nodePool = []
+
+function reuseNode(node, tag, data, children) {
+  node.tag = tag
+  node.data = data
+  node.children = children
+  return node
+}
+
+export function getNode(tag, data, children) {
+  if (nodePool.length > 0) {
+    return reuseNode(nodePool.pop(), tag, data, children)
+  } else {
+    return { tag: tag, data: data, children: children }
+  }
+}
+
+export function recoverNode(node) {
+  if (typeof node !== "string") {
+    nodePool.push(node)
+  }
+}
+
 export function h(tag, data) {
   var node
   var stack = []

--- a/src/h.js
+++ b/src/h.js
@@ -44,10 +44,6 @@ export function h(tag, data) {
   }
 
   return typeof tag === "string"
-    ? {
-        tag: tag,
-        data: data || {},
-        children: children
-      }
+    ? getNode(tag, data || {}, children)
     : tag(data, children)
 }


### PR DESCRIPTION
Anyone see a point in patch that I should be grabbing nodes for recycling that I missed?  This basic implementation is based on the gist @ngryman provided in slack the other day. https://gist.github.com/ngryman/69717b9b6eb57da2a50a9faad02fb004  

I was curious how this would work so I put it together, seems to be working well for our tests but I'm not certain we don't have cases where recycling causes an issue that isn't in current tests...

This is mainly just for discussion, not expecting this to be merged as is without at least adding some recycling test cases.