### PR TITLE
Allow the use of Promise that resolve to a state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -87,7 +87,10 @@ export function app(app) {
             }).data
           )
 
-          if (result != null && typeof result.then == "function") {
+          if (result == null) {
+          } else if (typeof result == "function") {
+            result = result(update)
+          } else if (typeof result.then == "function") {
             result.then(update)
           } else {
             update(result)

--- a/src/app.js
+++ b/src/app.js
@@ -81,8 +81,16 @@ export function app(app) {
             }).data
           )
 
-          if (result != null && result.then == null) {
-            repaint((state = merge(state, emit("update", result))))
+          function update(data) {
+            if (data != null) {
+              repaint((state = merge(state, emit("update", data))))
+            }
+          }
+
+          if (result != null && typeof result.then == "function") {
+            result.then(update)
+          } else {
+            update(result)
           }
 
           return result

--- a/src/app.js
+++ b/src/app.js
@@ -32,6 +32,12 @@ export function app(app) {
 
   return emit
 
+  function update(withState) {
+    if (withState != null) {
+      repaint((state = merge(state, emit("update", withState))))
+    }
+  }
+
   function repaint() {
     if (!locked) {
       requestAnimationFrame(render, (locked = !locked))
@@ -80,12 +86,6 @@ export function app(app) {
               data: data
             }).data
           )
-
-          function update(data) {
-            if (data != null) {
-              repaint((state = merge(state, emit("update", data))))
-            }
-          }
 
           if (result != null && typeof result.then == "function") {
             result.then(update)

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -45,7 +45,7 @@ test("update the state async", done => {
   })
 })
 
-test("update the state async using a promise", done => {
+test("update the state async using a promise with handler", done => {
   app({
     state: 1,
     view: state => h("div", {}, state),
@@ -64,6 +64,74 @@ test("update the state async using a promise", done => {
     },
     events: {
       init: (state, actions) => actions.delayAndChange(100)
+    }
+  })
+})
+
+test("update the state async using a thunk", done => {
+  app({
+    state: 1,
+    view: state => h("div", {}, state),
+    actions: {
+      delay: state => new Promise(resolve => setTimeout(() => resolve(), 20)),
+      delayAndChange: (state, actions, data) => (update) => {
+        actions.delay().then(() => {
+          update(state + data)
+
+          setTimeout(() => {
+            expect(document.body.innerHTML).toBe(`<div>${state + data}</div>`)
+            done()
+          })
+        })
+      }
+    },
+    events: {
+      init: (state, actions) => actions.delayAndChange(100)
+    }
+  })
+})
+
+test("update the state async using a promise", done => {
+  app({
+    state: 1,
+    view: state => h("div", {}, state),
+    actions: {
+      delay: state => new Promise(resolve => setTimeout(() => resolve(), 20)),
+      delayAndChange: (state, actions, data) => {
+        return actions.delay().then(() => {
+          return state + data
+        })
+      }
+    },
+    events: {
+      init: (state, actions) => actions.delayAndChange(100),
+      render: () => {
+        setTimeout(() => {
+          expect(document.body.innerHTML).toBe(`<div>101</div>`)
+          done()
+        })
+      }
+    }
+  })
+})
+
+test("update a state using then sync", done => {
+  app({
+    state: {
+      then: 1
+    },
+    view: state => h("div", null, state.then),
+    actions: {
+      add: state => ({ then: state.then + 1 })
+    },
+    events: {
+      init: (state, actions) => {
+        actions.add()
+      },
+      loaded: () => {
+        expect(document.body.innerHTML).toBe(`<div>2</div>`)
+        done()
+      }
     }
   })
 })


### PR DESCRIPTION
The following change follow the slack discussion regarding the feature allowing an action to return a Promise that resolve to a state.

Usage : 
```jsx
app({
  state: {
    issues: []
  },
  view: (state, actions) => (
    <main>
      { state.issues.map(issue => <h1>{issue.title}</h1>) }
      <button onclick={actions.issues}>fetch</button>
    </main>
  ),
  actions: {
    issues() {
      return fetch("https://api.github.com/repos/hyperapp/hyperapp/issues")
        .then(response => response.json())
        .then(issues => ({ issues }) )
    }
  }
})
```

or 

```jsx
app({
  state: {
    issues: []
  },
  view: (state, actions) => (
    <main>
      { state.issues.map(issue => <h1>{issue.title}</h1>) }
      <button onclick={actions.issues}>fetch</button>
    </main>
  ),
  actions: {
    async issues() {
      const response = await fetch("https://api.github.com/repos/hyperapp/hyperapp/issues")
      const issues = await response.json()
      return { issues }
    }
  }
})
```

When an action return a Promise. The main argument of the last `.then` clause will be used exactly like a sync action return.