### PR TITLE
Add onmove lifecycle event

### DIFF
--- a/docs/lifecycle-events.md
+++ b/docs/lifecycle-events.md
@@ -20,6 +20,12 @@ Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element))
 
 The onupdate event is fired every time the element's data is updated.
 
+## onmove
+
+Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element))
+
+The onmove event is fired (at least) every time the element's position among siblings is changed. Note that [virtual nodes](/docs/virtual-nodes.md) do not correspond to specific elements unless using [keys](/docs/keys.md). Hence the onmove event will only work for keyed nodes.
+
 ## onremove
 
 Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element))

--- a/src/app.js
+++ b/src/app.js
@@ -236,6 +236,8 @@ export function app(app) {
       var i = 0
       var j = 0
 
+      var moved = false
+
       while (j < len) {
         var oldElement = oldElements[i]
         var oldChild = oldNode.children[i]
@@ -259,12 +261,16 @@ export function app(app) {
           i++
         } else {
           if (oldKey === newKey) {
+            if (moved && newChild.data.onmove) newChild.data.onmove(reusableChild[0])
             patch(element, reusableChild[0], reusableChild[1], newChild, isSVG)
             i++
           } else if (reusableChild[0]) {
+            moved = true
+            if (newChild.data.onmove) newChild.data.onmove(reusableChild[0])
             element.insertBefore(reusableChild[0], oldElement)
             patch(element, reusableChild[0], reusableChild[1], newChild, isSVG)
           } else {
+            moved = true
             patch(element, oldElement, null, newChild, isSVG)
           }
 

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -98,3 +98,87 @@ test("onremove", done => {
     }
   })
 })
+
+test("onmove called when siblings moved", done => {
+  const called = {}
+  const handler = key => { called[key] = true }
+  app({
+    state: {
+      nodes: ["a", "b", "c", "d", "e", "f"]
+    },
+    actions: {
+      shuffle: state => {
+        state.nodes = ["a", "b", "e", "d", "c", "f"]
+        return state
+      }
+    },
+    events: {
+      loaded: (state, actions) => actions.shuffle(),
+      render: (state, actions) => {
+        setTimeout(_ => {
+          if (called.c && called.d && called.e && called.f) done()
+        }, 0)
+      }
+    },
+    view: state =>
+      h('div', {}, state.nodes.map(key =>
+        h('div', { key, onmove: el => handler(key) })
+      ))
+  })
+})
+
+test("onmove called when siblings removed", done => {
+  const called = {}
+  const handler = key => { called[key] = true }
+  app({
+    state: {
+      nodes: ["a", "b", "c", "d"]
+    },
+    actions: {
+      shuffle: state => {
+        state.nodes = ["a", "c", "d"]
+        return state
+      }
+    },
+    events: {
+      loaded: (state, actions) => actions.shuffle(),
+      render: (state, actions) => {
+        setTimeout(_ => {
+          if (called.c && called.d) done()
+        }, 0)
+      }
+    },
+    view: state =>
+      h('div', {}, state.nodes.map(key =>
+        h('div', { key, onmove: el => handler(key) })
+      ))
+  })
+})
+
+test("onmove called when siblings inserted", done => {
+  const called = {}
+  const handler = key => { called[key] = true }
+  app({
+    state: {
+      nodes: ["a", "c", "d"]
+    },
+    actions: {
+      shuffle: state => {
+        state.nodes = ["a", "b", "c", "d"]
+        return state
+      }
+    },
+    events: {
+      loaded: (state, actions) => actions.shuffle(),
+      render: (state, actions) => {
+        setTimeout(_ => {
+          if (called.c && called.d) done()
+        }, 0)
+      }
+    },
+    view: state =>
+      h('div', {}, state.nodes.map(key =>
+        h('div', { key, onmove: el => handler(key) })
+      ))
+  })
+})


### PR DESCRIPTION
Lifecycle even that fires for elements when their position among siblings changes. Since elements don't correspond to virtual nodes, unless those virtual nodes are keyed, this lifecycle event only makes sense for (and only works with) keyed nodes.

Now that onupdate is only called when a node's props change, this is the only (non-hacky) way to detect reordering.

Why? One use case is for animated transitions (moving elements to their new position smoothly).