### PR TITLE
replace onupdate with onrender

### DIFF
--- a/docs/lifecycle-events.md
+++ b/docs/lifecycle-events.md
@@ -14,11 +14,13 @@ Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element))
 
 The oninsert event is fired after the element is created and inserted into the DOM. Use this event to wrap third party libraries that require a reference to a DOM node, etc.
 
-## onupdate
+## onrender
 
-Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element))
+Type: ([element](https://developer.mozilla.org/en-US/docs/Web/API/Element), [attributes](/docs/virtual-nodes.md#attributes))
 
-The onupdate event is fired every time the element's data is updated.
+The onrender event is fired every time the virtual dom updates the element (excluding the first time, when it's created).
+
+Besides the element, the handler recieves as the second argument, the node's properties from the previous render. This allows you to execute logic conditionally based on what, if anything, has changed.
 
 ## onremove
 

--- a/src/app.js
+++ b/src/app.js
@@ -157,10 +157,10 @@ export function app(app) {
       name === "key" ||
       name === "oncreate" ||
       name === "oninsert" ||
-      name === "onupdate" ||
+      name === "onrender" ||
       name === "onremove"
     ) {
-      return name
+      /* noop */
     } else if (name === "style") {
       for (var i in merge(oldValue, (value = value || {}))) {
         element.style[i] = value[i] || ""
@@ -180,22 +180,17 @@ export function app(app) {
     }
   }
 
-  function updateElementData(element, oldData, data, cb) {
+  function updateElementData(element, oldData, data) {
     for (var name in merge(oldData, data)) {
       var value = data[name]
       var oldValue = oldData[name]
 
-      if (
-        value !== oldValue &&
-        value !== element[name] &&
-        setElementData(element, name, value, oldValue) == null
-      ) {
-        cb = data.onupdate
+      if (value !== oldValue && value !== element[name]) {
+        setElementData(element, name, value, oldValue)
       }
     }
-
-    if (cb != null) {
-      cb(element)
+    if (data.onrender) {
+      data.onrender(element, oldData)
     }
   }
 

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -37,48 +37,32 @@ test("oninsert", done => {
   })
 })
 
-test("fire onupdate if node data changes", done => {
-  app({
-    state: "foo",
-    view: state =>
-      h("div", {
-        class: state,
-        onupdate: done
-      }),
-    actions: {
-      change: state => "bar"
-    },
-    events: {
-      loaded: (state, actions) => {
-        actions.change()
+test("fire onrender each render with oldData", () => {
+  return new Promise((resolve, reject) => {
+
+    const dataA = {foo: "bar"}
+
+    const dataB = {
+      onrender: (el, oldData) => {
+        if (oldData && oldData.foo && oldData.foo === dataA.foo) {
+          resolve()
+        } else {
+          reject()
+        }
       }
     }
-  })
-})
 
-test("do not fire onupdate if data does not change", () => {
-  const noop = () => {}
-
-  return new Promise((resolve, reject) => {
     app({
-      state: "foo",
-      view: state =>
-        h("div", {
-          class: state,
-          oncreate: noop,
-          onupdate: reject,
-          oninsert: noop,
-          onremove: noop
-        }),
+      state: true,
       actions: {
-        change: state => "foo"
+        change: () => false
       },
       events: {
         loaded: (state, actions) => {
           actions.change()
-          setTimeout(resolve, 100)
         }
-      }
+      },
+      view: state => h("div", (state ? dataA : dataB))
     })
   })
 })


### PR DESCRIPTION
Onrender basically reinstates the old behavior of onupdate, with a more appropriate name.

If you have something you want to do *only* when some props (or some particular props) have changed, we now pass the old props as a second argument to `onrender` handlers, so you may use whatever logic is appropriate.

I thought this would let me shave off more bytes, but -10 bytes is at least something.