### PR TITLE
Remove mixins inside mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "module": "src/index.js",
   "license": "MIT",
   "repository": "hyperapp/hyperapp",
-  "files": ["src", "dist"],
+  "files": [
+    "src",
+    "dist"
+  ],
   "author": "Jorge Bucaran",
   "keywords": [
     "hyperapp",

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ export function app(app) {
   var state = {}
   var actions = {}
   var events = {}
-  var mixins = []
+  var mixins = app.mixins || []
   var view = app.view
   var root = app.root || document.body
   var node
@@ -20,8 +20,6 @@ export function app(app) {
     if (mixin.state != null) {
       state = merge(state, mixin.state)
     }
-
-    mixins = mixins.concat(mixin.mixins || [])
 
     initialize(actions, mixin.actions)
   }

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -121,32 +121,6 @@ test("don't overwrite actions in the same namespace", () => {
   })
 })
 
-test("mixin composition", () => {
-  const A = () => ({
-    state: {
-      foo: 1
-    }
-  })
-
-  const B = () => ({
-    mixins: [A],
-    state: {
-      bar: 2
-    }
-  })
-
-  app({
-    mixins: [B],
-    view: () => "",
-    events: {
-      init: state => {
-        expect(state.bar).toBe(2)
-        expect(state.foo).toBe(1)
-      }
-    }
-  })
-})
-
 test("receive emit function", done => {
   app({
     mixins: [


### PR DESCRIPTION
So I think this feature didn't go out as well in retrospect.

In order to make a mixin workable with this feature, you have to pass an option that changes the namespace of the actions, state, and events on the app.  Only way to avoid conflicts if it appears multiple times (e.g., you use it and another mixin uses it).  For example:

```js
// Takes an option:
actions[namespace].foo()

// Versus hardcoding it:
actions.myMixin.foo()
```

Only thing that would make this better is if there was some concept of local state and actions built-in.  For example `state.local` and `actions.local` resembling a unique namespace no matter where it is used.