### PR TITLE
Give to afterAction event the same behavior as beforeAction

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -78,9 +78,9 @@ export function app(app) {
 
       if (typeof action === "function") {
         namespace[key] = function(data) {
-          var result = emit(
-            "afterAction",
-            action(
+          var result = emit("afterAction", {
+            name: name,
+            data: action(
               state,
               actions,
               emit("beforeAction", {
@@ -88,7 +88,7 @@ export function app(app) {
                 data: data
               }).data
             )
-          )
+          }).data
 
           if (result == null) {
           } else if (typeof result === "function") {

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -61,6 +61,30 @@ test("beforeAction", done => {
   })
 })
 
+test("afterAction", done => {
+  app({
+    state: "",
+    view: state => h("div", null, state),
+    actions: {
+      set: (state, actions, data) => "bar"
+    },
+    events: {
+      init: (state, actions) => {
+        actions.set("foo")
+      },
+      loaded: () => {
+        expect(document.body.innerHTML).toBe(`<div>baz</div>`)
+        done()
+      },
+      afterAction: (state, actions, { name, data }) => {
+        if (name === "set") {
+          return { data: "baz" }
+        }
+      }
+    }
+  })
+})
+
 test("update", done => {
   app({
     state: 1,


### PR DESCRIPTION
At the moment only `beforeAction` give the called `action` name.

It will be a better user experience to give to both event the same behavior.  Giving the action `name` will grant all common use cases.

Added tests coverage for `afterAction` too