### PR TITLE
enhanced the node checking expression

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -12,7 +12,7 @@ export function h(tag, data) {
       for (var i = node.length; i--; ) {
         stack[stack.length] = node[i]
       }
-    } else if (node !== null && typeof node !== "boolean") {
+    } else if (node != null && typeof node !== "boolean") {
       if (typeof node === "number") {
         node = node + ""
       }

--- a/src/h.js
+++ b/src/h.js
@@ -12,7 +12,7 @@ export function h(tag, data) {
       for (var i = node.length; i--; ) {
         stack[stack.length] = node[i]
       }
-    } else if (node && typeof node !== "boolean") {
+    } else if (node !== null && typeof node !== "boolean") {
       if (typeof node === "number") {
         node = node + ""
       }

--- a/src/h.js
+++ b/src/h.js
@@ -12,7 +12,7 @@ export function h(tag, data) {
       for (var i = node.length; i--; ) {
         stack[stack.length] = node[i]
       }
-    } else if (node != null && node !== true && node !== false) {
+    } else if (node && typeof node !== "boolean") {
       if (typeof node === "number") {
         node = node + ""
       }


### PR DESCRIPTION
- using `if(variable) {}` is a shortcut for checking if the value exist or not so values like `undefined`, `null`, `0`, `""`, `false` and `NaN` will not pass

- you were checking if `node` is not equal to `true` or `false` and those are `Boolean` values so instead it will easier to check the value type if it's `boolean` or not