### PR TITLE
Fix issue where two structures that differ only on a value attribute are not updated correctly

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -67,3 +67,47 @@ test("optional view", done => {
     }
   })
 })
+
+test("view values update upon state change", done => {
+  document.body.innerHTML = `<div id="app"></div>`
+  const emit = app({
+    root: document.getElementById("app"),
+    state: { changeInput: false },
+    view: state => h("input", { id: state.changeInput ? "foo" : "bar", "value" : state.changeInput ? "fizz" : "buzz" }),
+    actions: {
+      updateInput (app, state, actions) {
+        state.changeInput = true
+        return state
+      }
+    },
+    events: {
+      updateView (state, actions) {
+        actions.updateInput()
+      },
+      load () {
+        expect(document.body.innerHTML).toBe(
+          `<div id="app"></div>`
+        )
+      }
+    }
+  })
+
+  const firstRenderId = requestAnimationFrame(() => {
+    expect(document.body.innerHTML).toBe(
+      `<input id="bar" value="buzz">`
+    )
+
+    emit("updateView")
+
+    const secondRenderId = requestAnimationFrame(() => {
+      console.log(document.body.innerHTML)
+      expect(document.body.innerHTML).toBe(
+        `<input id="foo" value="fizz">`
+      )
+      done()
+      cancelAnimationFrame(secondRenderId)
+    })
+
+    cancelAnimationFrame(firstRenderId)
+  })
+})


### PR DESCRIPTION
This PR aims to solve an issue I'm currently facing when the new html structure that needs to be rendered only differs in a single "value" attribute.

Bug example: https://codepen.io/fsodano/pen/YxGRZX

Here's where the error was introduced:
https://github.com/hyperapp/hyperapp/commit/010172ca36596deef445ec2292478cd99c0c1a5b a change was introduced in the way hypearpp identifies if an element needs to be updated or not.

This is the old way, where it would check if the oldValue was present in the element, if the attribute name was either "value" or "checked".
```javascript
  function updateElementData(element, oldData, data) {
    for (var name in merge(oldData, data)) {
      var value = data[name]
      var oldValue =
        name === "value" || name === "checked" ? element[name] : oldData[name]
      var onupdate

      if (name === "onupdate") {
      } else if (value !== oldValue) {
        setElementData(element, name, value, oldValue)
        onupdate = data.onupdate
      }
    }

    if (onupdate != null) {
      onupdate(element)
    }
  }
```

This is the new way, which removed that check, and also inverted the priority of the source of truth for the correct data (before it was the element, and then the oldData, now it's backwards)

```javascript
  function updateElementData(element, oldData, data, cb) {
    for (var name in merge(oldData, data)) {
      var value = data[name]
      var oldValue = oldData[name]

      if (
        value !== oldValue &&
        value !== element[name] &&
        setElementData(element, name, value, oldValue) == null
      ) {
        cb = data.onupdate
      }
    }

    if (cb != null) {
      cb(element)
    }
  }
```
