### PR TITLE
Support for iterable rendering

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -1,9 +1,13 @@
 var i
 var stack = []
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator || '@@iterator'
 
 export function h(tag, data) {
   var node
   var children = []
+  var iterator
+  var next
+  var subStack
 
   for (i = arguments.length; i-- > 2; ) {
     stack.push(arguments[i])
@@ -14,6 +18,13 @@ export function h(tag, data) {
       for (i = node.length; i--; ) {
         stack.push(node[i])
       }
+    } else if (node != null && typeof node === "object" && typeof node[ITERATOR_SYMBOL] === "function") {
+      iterator = node[ITERATOR_SYMBOL]()
+      subStack = []
+      while(!(next = iterator.next()).done) {
+        subStack.push(next.value)
+      }
+      stack.push(subStack)
     } else if (node != null && node !== true && node !== false) {
       if (typeof node === "number") {
         node = node + ""

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -100,3 +100,59 @@ test("components", () => {
     ]
   })
 })
+
+test("iterables children", ()  => {
+  function* iterable() {
+    yield "Hello"
+    yield " world"
+    yield "!"
+  }
+
+  const expectedSimple = {
+    tag     : 'div',
+    data    : {},
+    children: [
+      'Hello',
+      ' world',
+      '!'
+    ]
+  }
+
+  expect(h("div", {}, iterable())).toEqual(expectedSimple)
+
+  function* nestedIterable() {
+    yield h(
+      "div",
+      {},
+      iterable()
+    )
+  }
+
+  const expectedNested = {
+    tag     : 'div',
+    data    : {},
+    children: [
+      {
+        'children': [
+          'Hello',
+          ' world',
+          '!',
+        ],
+        'data'    : {},
+        'tag'     : 'div',
+      }
+    ]
+  }
+
+  expect(h("div", {}, nestedIterable())).toEqual(expectedNested)
+
+  function * emptyIterable() {}
+
+  const expectedEmpty = {
+    tag     : 'div',
+    data    : {},
+    children: []
+  }
+
+  expect(h("div", {}, emptyIterable())).toEqual(expectedEmpty)
+})


### PR DESCRIPTION
Enable the use of iterable protocal on children.
So it will support generator, immutable.js collections, etc...
Example : 
```jsx
import { List } from "immutable.js"
const technos = List(["Hyperapp", "Preact", "Inferno"])
const technosList = () => <ul>
  {
    technos.map(name => <li>{name}</li>)
  }
</ul>
```
