### PR TITLE
Introduce merge event.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,8 +65,15 @@ export function app(props) {
   }
 
   function update(withState) {
-    if (withState && (withState = emit("update", merge(appState, withState)))) {
-      requestRender((appState = withState))
+    if (withState) {
+      var newState = emit("merge", withState)
+      if (newState === withState) {
+        newState = merge(appState, withState)
+      }
+
+      if ((newState = emit("update", newState))) {
+        requestRender((appState = newState))
+      }
     }
     return appState
   }


### PR DESCRIPTION
The merge event is fired before update, letting you intercept the partial state before it's merged with the app state. Use merge to override the default  merge (shallow) strategy, e.g., deep merge.

Use it like any other event:

```jsx
  events: {
    merge(state, actions, partialState) {
      return Object.assign({}, state, partialState)
    }
  }
```

⚠️ The code works, but there are no tests. However, **I am not 100%** sure I want to add a new event until I am convinced we have a good use case for it.

Looks good though! 

/cc @NoobLad @MatejMazur 