### PR TITLE
Call thunks inside update function.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,10 +36,7 @@ export function app(props) {
       if (typeof action === "function") {
         actions[key] = function(data) {
           emit("action", { name: name, data: data })
-
-          var result = emit("resolve", action(appState, appActions, data))
-
-          return typeof result === "function" ? result(update) : update(result)
+          return update(emit("resolve", action(appState, appActions, data)))
         }
       } else {
         initialize(actions[key] || (actions[key] = {}), action, name)
@@ -65,6 +62,9 @@ export function app(props) {
   }
 
   function update(withState) {
+    if (typeof withState === "function") {
+      return withState(update)
+    }
     if (withState && (withState = emit("update", merge(appState, withState)))) {
       requestRender((appState = withState))
     }


### PR DESCRIPTION
Before we would call thunks inside wrapped actions, now thunks are called inside the update function.

This allows you to pass also a thunk to update and it will be called.

```js
actions: {
  someAction(state, actions, data) {
    return update => {
      update(update => {
        update(update => {
          update(update => {
            update({ value })
          })
        })
      })
    }
  }
}
```


Either way, thunks are called immediately after an action is called.

This also reduces the bundlesize by 5 bytes ;)

