### PR TITLE
Add ActionInfo to resolve and update events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -159,8 +159,8 @@ See [Events](/docs/events.md).
 <a id="load"></a>load(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#root">Root</a>): <a href="#vnode">VNode</a>
 <a id="render"></a>render(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#view">View</a>): <a href="#view">View</a>
 <a id="action"></a>action(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#actioninfo">ActionInfo</a>): <a href="#actioninfo">ActionInfo</a>
-<a id="resolve"></a>resolve(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#actionresult">ActionResult</a>): <a href="#actionresult">ActionResult</a>
-<a id="update_event"></a>update(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#state">State</a>): <a href="#state">State</a>
+<a id="resolve"></a>resolve(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#actionresult">ActionResult</a>, <a href="#actioninfo">ActionInfo</a>): <a href="#actionresult">ActionResult</a>
+<a id="update_event"></a>update(<a href="#state">State</a>, <a href="#actions">Actions</a>, <a href="#state">State</a>, <a href="#actioninfo">ActionInfo</a>): <a href="#state">State</a>
 </pre>
 
 #### CustomEvent

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -94,6 +94,9 @@ test("async updates", done => {
     events: {
       load(state, actions) {
         actions.upAsync(1)
+      },
+      update(state, actions, nextState, action) {
+        expect(action).toEqual({ name: "up", data: 1 })
       }
     }
   })
@@ -130,6 +133,10 @@ test("thunks", done => {
     events: {
       load(state, actions) {
         actions.upAsync(1)
+      },
+      update(state, actions, nextState, action) {
+        expect(action).toEqual({ name: "upAsync", data: 1
+       })
       }
     }
   })
@@ -169,6 +176,9 @@ test("thunks + promises", done => {
         return result && typeof result.then === "function"
           ? update => result.then(update)
           : result
+      },
+      update(state, actions, nextState, action) {
+        expect(action).toEqual({ name: "upAsync", data: 1 })
       }
     }
   })

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -113,11 +113,12 @@ test("resolve", done => {
       load(state, actions) {
         actions.set("bar")
       },
-      resolve(state, actions, result) {
+      resolve(state, actions, result, action) {
         if (typeof result === "string") {
           //
           // Query strings as a valid ActionResult.
           //
+          expect(action).toEqual({ name: "set", data: "bar" })
           const [key, value] = result.slice(1).split("=")
           return { [key]: value }
         }
@@ -152,7 +153,8 @@ test("update", done => {
       load(state, actions) {
         actions.set(null)
       },
-      update(state, actions, nextState) {
+      update(state, actions, nextState, action) {
+        expect(action).toEqual({ name: "set", data: null })
         if (typeof nextState.value !== "string") {
           return state
         }


### PR DESCRIPTION
In today's API the `ActionInfo` object is made available to the `action` event, but not to the `resolve` or `update` events, even though both of these had an original action that caused them to happen. It can be helpful to have access to the action that triggered a state update in larger/complex apps. It can also be useful to know the original action that was fired when deciding what to do when it resolves.

Now `update` has a new parameter tracking the action that caused it, including forwarding it on in the event of thunks/async. Also `emit` has a new parameter for the action that eventually led to this event, and it calls the callback with this action added. I'm open to rearranging these, but I wanted to start with a change that was backward compatible in adding the new feature.

Test coverage was updated including async. Docs were updated. The gzipped bundle grew by 19 bytes 🤷‍♂️ 