### PR TITLE
Reuse TextNodes in patch()

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -253,11 +253,15 @@ export function app(props) {
         }
       }
     } else if (element && node !== element.nodeValue) {
-      element = parent.insertBefore(
-        createElement(node, isSVG),
-        (nextSibling = element)
-      )
-      removeElement(parent, nextSibling, oldNode.data)
+      if (typeof node === "string" && typeof oldNode === "string") {
+        element.nodeValue = node
+      } else {
+        element = parent.insertBefore(
+          createElement(node, isSVG),
+          (nextSibling = element)
+        )
+        removeElement(parent, nextSibling, oldNode.data)
+      }
     }
 
     return element


### PR DESCRIPTION
I wanted to submit just this piece out of the recycle PR, I feel it has merit on it's own.  Below are two screen shots of chrome devtools before and after this patch is applied to hyperapp.

The first screenshot here is current master branch, notice the nodes count in chrome devtools performance (8k - 108k Nodes), and you can see the green line drop when GC has to kick in for recycling the TextNodes.
![before-reuse-text-nodes](https://user-images.githubusercontent.com/5376837/29753362-d4047438-8b24-11e7-85cc-d8eceb2cb859.png)

Then after this patch notice that the number of Nodes created in DBMon are drastically reduced over similar time frame (the parts of that app that only update string values in text nodes no longer cause a large build up of TextNodes for browser to GC)  (3K - 4K Nodes)
![after-reuse-text-nodes](https://user-images.githubusercontent.com/5376837/29753389-5386e240-8b25-11e7-91e1-38516a03ec32.png)

Hoping we can discuss if this has any unwanted side effects that make it more desirable to keep replacing the TextNodes instead of reusing them.