### PR TITLE
Remove Mixinception from Docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -184,7 +184,6 @@ Array&lt<a href="#mixin">Mixin</a>&gt
   state: <a href="#state">State</a>,
   actions: <a href="#actions">Actions</a>,
   events: <a href="#events">Events</a>,
-  mixins: <a href="#mixins">Mixins</a>,
 }
 </pre>
 


### PR DESCRIPTION
Currently mixins are not allowed within other mixins. There will be a separate flame war on the merits of changing that. This just updates the docs to reflect the current reality.