### PR TITLE
[DOCS] Fix "resolve" example for promises

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -76,7 +76,7 @@ app({
   events: {
     resolve(state, actions, result) {
       if (result && typeof result.then === "function") {
-        return result.then(update) && result
+        return update => result.then(update) && result
       }
     }
   }


### PR DESCRIPTION
Promise handling example wasn't returning a function, and would not work.

Used this code last night in a project, and it works nicely!

Though I do have a question.  Why return the `&& result`?  The observable example doesn't do that.