### PR TITLE
Allow update to take a reducer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ yarn.lock
 package-lock.json
 
 # Misc
-sandbox
+example
 node_modules
 coverage
 *.xml

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@
   - [Root](#root)
 - [Emit](#emit)
 - [Update](#update)
+  - [Reducer](#reducer)
 
 <!-- /TOC -->
 
@@ -208,7 +209,12 @@ See [Custom Events](/docs/events.md#custom-events).
 See [Thunks](/docs/actions.md#thunks).
 
 <pre>
-(<a href="#state">State</a>): any
+(<a href="#state">State</a> | <a href="#reducer">Reducer</a>): any
 </pre>
 
+### Reducer
+
+<pre>
+(<a href="#state">State</a>): <a href="#state">State</a> | Reducer
+</pre>
 

--- a/src/app.js
+++ b/src/app.js
@@ -36,7 +36,10 @@ export function app(props) {
       if (typeof action === "function") {
         actions[key] = function(data) {
           emit("action", { name: name, data: data })
-          return update(emit("resolve", action(appState, appActions, data)))
+
+          var result = emit("resolve", action(appState, appActions, data))
+
+          return typeof result === "function" ? result(update) : update(result)
         }
       } else {
         initialize(actions[key] || (actions[key] = {}), action, name)
@@ -63,7 +66,7 @@ export function app(props) {
 
   function update(withState) {
     if (typeof withState === "function") {
-      return withState(update)
+      return update(withState(appState))
     }
     if (withState && (withState = emit("update", merge(appState, withState)))) {
       requestRender((appState = withState))

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -135,7 +135,7 @@ test("thunks", done => {
   })
 })
 
-test("thunks + promises", done => {
+test("thunks", done => {
   app({
     view: state =>
       h(
@@ -156,19 +156,16 @@ test("thunks + promises", done => {
     },
     actions: {
       upAsync(state, actions, data) {
-        return mockDelay().then(() => ({
-          value: state.value + data
-        }))
+        return update => {
+          mockDelay().then(() => {
+            update(state => ({ value: state.value + data }))
+          })
+        }
       }
     },
     events: {
       load(state, actions) {
         actions.upAsync(1)
-      },
-      resolve(state, actions, result) {
-        return result && typeof result.then === "function"
-          ? update => result.then(update)
-          : result
       }
     }
   })


### PR DESCRIPTION
A reducer is a function that takes the state and returns a new state or a reducer.
    
```js
update(state => {
  return { value: state.value + 1 }
}
```    
    
This allows you to get the current & latest state inside the callback of some async call.
    
The alternative is using the state that was passed to the action that originated the async call. The problem is that this reference to the state may have gone out-of-date if other actions run and finished during the async process and changed the state.