### PR TITLE
Default mixin.events to empty object

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ export function app(props) {
   return emit
 
   function initialize(actions, withActions, lastName) {
-    Object.keys(withActions || []).map(function(key) {
+    Object.keys(withActions || {}).map(function(key) {
       var action = withActions[key]
       var name = lastName ? lastName + "." + key : key
 

--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ export function app(props) {
   appMixins.concat(props).map(function(mixin) {
     mixin = typeof mixin === "function" ? mixin(emit) : mixin
 
-    Object.keys(mixin.events || []).map(function(key) {
+    Object.keys(mixin.events || {}).map(function(key) {
       appEvents[key] = (appEvents[key] || []).concat(mixin.events[key])
     })
 


### PR DESCRIPTION
Cool library. Just taking a look at the source.  I don't think this matters from a code execution standpoint (you'll get an empty array of keys with [] or {}) but it caused me to do a double take.  I was looking at the logger mixin source https://github.com/hyperapp/logger/blob/master/src/index.js#L16 where events is an object to see how it gets handled and spotted this.