### PR TITLE
add short circuit for patching memoized vnodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,8 @@ function app(props, container) {
   }
 
   function patch(parent, element, oldNode, node, isSVG, nextSibling) {
-    if (oldNode == null) {
+    if (oldNode === node) {
+    } else if (oldNode == null) {
       element = parent.insertBefore(createElement(node, isSVG), element)
     } else if (node.type != null && node.type === oldNode.type) {
       updateElement(element, oldNode.props, node.props)


### PR DESCRIPTION
this adds a short circuit to patch for memoized components...

example memoize:
```js
/*
* memoize.js
* by @philogb and @addyosmani
* with further optimizations by @mathias
* and @DmitryBaranovsk
* perf tests: http://bit.ly/q3zpG3
* Released under an MIT license.
*/
function memoize( fn ) {
    return function () {
        var args = Array.prototype.slice.call(arguments),
            hash = "",
            i = args.length;
        currentArg = null;
        while (i--) {
            currentArg = args[i];
            hash += (currentArg === Object(currentArg)) ?
            JSON.stringify(currentArg) : currentArg;
            fn.memoize || (fn.memoize = {});
        }
        return (hash in fn.memoize) ? fn.memoize[hash] :
        fn.memoize[hash] = fn.apply(this, args);
    };
}
```

Users would wrap their components/view with this method to skip patching vnodes which have not changed.

This PR satisifies the following issue: https://github.com/hyperapp/hyperapp/issues/373