### PR TITLE
Typo causing  'Cannot read property 'key'' error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -287,7 +287,7 @@ export function app(props) {
 
       for (var i in oldKeyed) {
         var keyedNode = oldKeyed[i]
-        var reusableNode = keyedNode[1]
+        var reusableNode = keyedNode[i]
         if (!keyed[reusableNode.props.key]) {
           removeElement(element, keyedNode[0], reusableNode.props)
         }


### PR DESCRIPTION
It seems that there is a typo in app.js which causing 1 instead of i to be used as a index lookup in keyed value. 
