### PR TITLE
Update typescript definitions for release 0.14

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -5,7 +5,7 @@ export as namespace Hyperapp
 /** The VDOM representation of an Element
  *
  * @memberOf [VDOM]
-*/
+ */
 export interface VNode<Props> {
   tag: string
   props: Props
@@ -15,9 +15,13 @@ export interface VNode<Props> {
 /** In the VDOM a Child could be either a VNode or a string
  *
  * @memberOf [VDOM]
-*/
+ */
 export type VNodeChild<Props> = VNode<Props> | string
 
+/** A Component is a function that return a custom VNode
+ *
+ * @memberOf [VDOM]
+ */
 export interface Component<Props> {
   /** A Component is a function that return a custom VNode
    *
@@ -26,6 +30,10 @@ export interface Component<Props> {
   (props: Props, children: VNodeChild<{} | null>[]): VNode<{}>
 }
 
+/**The type for the children parameter accepted by h().
+ * 
+ * @memberOf [VDOM]
+ */
 export type VNodeChildren =
   | Array<VNodeChild<{} | null> | number>
   | VNodeChild<{} | null>
@@ -46,12 +54,24 @@ export function h<Props>(
 
 /** @namespace [App] */
 
+/** The application state.
+ * 
+ * @memberOf [App]
+ */
 export interface State {}
 
+/** Thunk that may be returned bay an action.
+ * 
+ * @memberOf [App]
+ */
 export interface Thunk {
   (update: Function): any | null | void
 }
 
+/** Result of an action.
+ * 
+ * @memberOf [App]
+ */
 export type ActionResult<State extends Hyperapp.State> =
   | Partial<State>
   | Thunk
@@ -59,10 +79,18 @@ export type ActionResult<State extends Hyperapp.State> =
   | null
   | void
 
+/** The interface for a single action (exposed when calling actions).
+ * 
+ * @memberOf [App]
+ */
 export interface Action<State extends Hyperapp.State, Data> {
   (data: Data): ActionResult<State>
 }
 
+/** The interface for actions (exposed when calling actions).
+ * 
+ * @memberOf [App]
+ */
 export interface Actions<
   State extends Hyperapp.State & Partial<Record<keyof Actions<State>, any>>
 > {
@@ -71,6 +99,10 @@ export interface Actions<
     | Action<State, any>
 }
 
+/** The interface for a single action (exposed when implementing actions).
+ * 
+ * @memberOf [App]
+ */
 export interface InternalAction<
   State extends Hyperapp.State,
   Actions extends Hyperapp.Actions<State>
@@ -78,6 +110,10 @@ export interface InternalAction<
   (state: State, actions: Actions, data: any): ActionResult<State>
 }
 
+/** The interface for actions (exposed when implementing actions).
+ * 
+ * @memberOf [App]
+ */
 export type InternalActions<
   State extends Hyperapp.State & Partial<Record<keyof Actions, any>>,
   Actions extends Hyperapp.Actions<State>
@@ -87,27 +123,10 @@ export type InternalActions<
     | InternalActions<State[P], Actions[P] & Hyperapp.Actions<State[P]>>
 }
 
-export interface Events<
-  State extends Hyperapp.State,
-  Actions extends Hyperapp.Actions<State>
-> {
-  [action: string]:
-    | ((state: State, actions: Actions, data: any) => any)
-    | undefined
-}
-
-export interface DefaultEvents<
-  State extends Hyperapp.State,
-  Actions extends Hyperapp.Actions<State>
-> extends Hyperapp.Events<State, Actions> {
-  load?: (state: State, actions: Actions) => void
-  resolve?: (
-    state: State,
-    actions: Actions,
-    result: ActionResult<State>
-  ) => ActionResult<State>
-}
-
+/** The view function.
+ * 
+ * @memberOf [App]
+ */
 export interface View<
   State extends Hyperapp.State,
   Actions extends Hyperapp.Actions<State>
@@ -115,47 +134,28 @@ export interface View<
   (state: State, actions: Actions): VNode<{}>
 }
 
-export interface Mixin<
-  State extends Hyperapp.State & Record<keyof Actions, any>,
-  Actions extends Hyperapp.Actions<State>,
-  Events extends Hyperapp.DefaultEvents<State, Actions>
-> {
-  (): App<State, Actions, Events>
-  (): (emit: Emit<State, Actions, Events>) => App<State, Actions, Events>
-}
-
+/** Input parameter of the app() function.
+ * 
+ * @memberOf [App]
+ */
 export interface App<
   State extends Hyperapp.State & Record<keyof Actions, any>,
-  Actions extends Hyperapp.Actions<State>,
-  Events extends Hyperapp.DefaultEvents<State, Actions>
+  Actions extends Hyperapp.Actions<State>
 > {
   state?: State
   actions?: InternalActions<State, Actions>
-  events?: Events
   view?: View<State, Actions>
   root?: HTMLElement | null
-  mixins?: Mixin<{}, {}, {}>[]
 }
 
-export interface Emit<
-  State extends Hyperapp.State,
-  Actions extends Hyperapp.Actions<State>,
-  Events extends Hyperapp.Events<State, Actions>
-> {
-  /** Call succesively each event handler of the specified event
-   * @param name  The name of the event to call
-   * @param data  Will be reduced by each event handler
-   *
-   * @memberOF [App]
-  */
-  (name: keyof Events, data?: any): any
-}
-
+/** The app() function, main entry point of Hyperapp's API.
+ * 
+ * @memberOf [App]
+ */
 export function app<
   State extends Hyperapp.State & Record<keyof Actions, any>,
-  Actions extends Hyperapp.Actions<State>,
-  Events extends Hyperapp.Events<State, Actions>
->(app: App<State, Actions, Events>): Emit<State, Actions, Events>
+  Actions extends Hyperapp.Actions<State>
+>(app: App<State, Actions>): Actions
 
 /** @namespace [JSX] */
 

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -6,6 +6,10 @@ interface Module1State extends Hyperapp.State {
   count: number
 }
 
+const module1InitialState: Module1State = {
+  count: 0
+}
+
 interface Module1Actions extends Hyperapp.Actions<Module1State> {
   sub(value: number): Partial<Module1State>
   add(value: number): Partial<Module1State>
@@ -20,6 +24,10 @@ const module1Actions: Hyperapp.InternalActions<Module1State, Module1Actions> = {
 
 interface Module2State {
   count: number
+}
+
+const module2InitialState: Module2State = {
+  count: 0
 }
 
 interface Module2Actions extends Hyperapp.Actions<Module2State> {
@@ -44,6 +52,14 @@ interface State extends Hyperapp.State {
   }
 }
 
+const initialState: State = {
+  module1: module1InitialState,
+  module2: module2InitialState,
+  unused2: {
+    foo: 'bar'
+  }
+}
+
 interface Actions extends Hyperapp.Actions<State> {
   module1: Module1Actions
   module2: Module2Actions
@@ -54,22 +70,8 @@ const actions: Hyperapp.InternalActions<State, Actions> = {
   module2: module2Actions
 }
 
-interface Events extends Hyperapp.Events<State, Actions> {
-  log: (state: State, actions: Actions, value: string) => void
-}
-
-const emit = app<State, Actions, Events>({
-  state: {
-    module1: {
-      count: 0
-    },
-    module2: {
-      count: 0
-    },
-    unused2: {
-      foo: "I have to set a value here, otherwise compilation error."
-    }
-  },
+const appActions = app<State, Actions>({
+  state: initialState,
   // no need to set the types here
   view: (state, actions) => (
     <main>
@@ -88,13 +90,6 @@ const emit = app<State, Actions, Events>({
       </p>
     </main>
   ),
-  actions,
-  events: {
-    log(state, actions, value) {
-      console.log(value + " " + state.module1.count)
-    }
-  },
+  actions,  
   root: document.getElementById("app")
 })
-
-emit("log", "Hello")


### PR DESCRIPTION
Update typescript definitions:
 - update actions definition to reflect the fragmented state
 - delete mixins and events definitions
 - update the test to utilize fragmented state