### PR TITLE
Introduce init and modules. Close #406.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,9 +65,9 @@ export function app(props) {
 
     initActions(state, actions, module.actions)
 
-    Object.keys(module.modules || {}).map(function(i) {
+    for (var i in module.modules) {
       init(module.modules[i], (state[i] = {}), (actions[i] = {}))
-    })
+    }
   }
 
   function initActions(state, actions, source) {

--- a/src/h.js
+++ b/src/h.js
@@ -1,7 +1,7 @@
 var i
 var stack = []
 
-export function h(tag, props) {
+export function h(type, props) {
   var node
   var children = []
 
@@ -19,11 +19,7 @@ export function h(tag, props) {
     }
   }
 
-  return typeof tag === "string"
-    ? {
-        tag: tag,
-        props: props || {},
-        children: children
-      }
-    : tag(props || {}, children)
+  return typeof type === "string"
+    ? { type: type, props: props || {}, children: children }
+    : type(props || {}, children)
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -39,26 +39,46 @@ test("throttling", done => {
 })
 
 test("hoa", done => {
-  function foo(app) {
-    return props =>
-      app(
-        Object.assign(props, {
-          state: { value: 1 }
+  function B(app) {
+    function enhancedApp(props) {
+      return app(
+        Object.assign({}, props, {
+          state: Object.assign(props.state, {
+            value: props.state.value + 1
+          })
         })
       )
+    }
+
+    return props =>
+      typeof props === "function" ? props(enhancedApp) : enhancedApp(props)
   }
 
-  app(foo)({
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe("<div>1</div>")
-            done()
-          }
-        },
-        state.value
+  function A(app) {
+    function enhancedApp(props) {
+      return app(
+        Object.assign({}, props, {
+          state: Object.assign(props.state, {
+            value: props.state.value + 1
+          })
+        })
       )
+    }
+
+    return props =>
+      typeof props === "function" ? props(enhancedApp) : enhancedApp(props)
+  }
+
+  app(A)(B)({
+    state: {
+      value: 0
+    },
+    init(state) {
+      expect(state).toEqual({
+        value: 2
+      })
+
+      done()
+    }
   })
 })

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -1,48 +1,12 @@
 import { h, app } from "../src"
 
-function testTrees(name, trees) {
-  test(name, done => {
-    app({
-      root: document.body,
-      view: (state, actions) =>
-        h(
-          "main",
-          {
-            oncreate: actions.next,
-            onupdate: actions.next
-          },
-          [trees[state.index].tree]
-        ),
-      state: {
-        index: 0
-      },
-      actions: {
-        up(state) {
-          return { index: state.index + 1 }
-        },
-        next(state, actions) {
-          expect(document.body.innerHTML).toBe(
-            `<main>${trees[state.index].html.replace(/\s{2,}/g, "")}</main>`
-          )
-
-          if (state.index === trees.length - 1) {
-            return done()
-          }
-
-          actions.up()
-        }
-      }
-    })
-  })
-}
-
 window.requestAnimationFrame = setTimeout
 
 beforeEach(() => {
   document.body.innerHTML = ""
 })
 
-testTrees("replace element", [
+testTreeSegue("replace element", [
   {
     tree: h("main", {}),
     html: `<main></main>`
@@ -53,7 +17,7 @@ testTrees("replace element", [
   }
 ])
 
-testTrees("replace child", [
+testTreeSegue("replace child", [
   {
     tree: h("main", {}, [h("div", {}, "foo")]),
     html: `
@@ -72,7 +36,7 @@ testTrees("replace child", [
   }
 ])
 
-testTrees("insert children on top", [
+testTreeSegue("insert children on top", [
   {
     tree: h("main", {}, [
       h(
@@ -163,7 +127,7 @@ testTrees("insert children on top", [
   }
 ])
 
-testTrees("remove text node", [
+testTreeSegue("remove text node", [
   {
     tree: h("main", {}, [h("div", {}, ["foo"]), "bar"]),
     html: `
@@ -183,7 +147,7 @@ testTrees("remove text node", [
   }
 ])
 
-testTrees("replace keyed", [
+testTreeSegue("replace keyed", [
   {
     tree: h("main", {}, [
       h(
@@ -224,7 +188,7 @@ testTrees("replace keyed", [
   }
 ])
 
-testTrees("reorder keyed", [
+testTreeSegue("reorder keyed", [
   {
     tree: h("main", {}, [
       h(
@@ -344,7 +308,7 @@ testTrees("reorder keyed", [
   }
 ])
 
-testTrees("grow/shrink keyed", [
+testTreeSegue("grow/shrink keyed", [
   {
     tree: h("main", {}, [
       h(
@@ -502,7 +466,7 @@ testTrees("grow/shrink keyed", [
   }
 ])
 
-testTrees("mixed keyed/non-keyed", [
+testTreeSegue("mixed keyed/non-keyed", [
   {
     tree: h("main", {}, [
       h(
@@ -602,7 +566,7 @@ testTrees("mixed keyed/non-keyed", [
   }
 ])
 
-testTrees("styles", [
+testTreeSegue("styles", [
   {
     tree: h("div"),
     html: `<div></div>`
@@ -621,7 +585,7 @@ testTrees("styles", [
   }
 ])
 
-testTrees("update element data", [
+testTreeSegue("update element data", [
   {
     tree: h("div", { id: "foo", class: "bar" }),
     html: `<div id="foo" class="bar"></div>`
@@ -632,7 +596,7 @@ testTrees("update element data", [
   }
 ])
 
-testTrees("removeAttribute", [
+testTreeSegue("removeAttribute", [
   {
     tree: h("div", { id: "foo", class: "bar" }),
     html: `<div id="foo" class="bar"></div>`
@@ -643,7 +607,7 @@ testTrees("removeAttribute", [
   }
 ])
 
-testTrees("skip setAttribute for functions", [
+testTreeSegue("skip setAttribute for functions", [
   {
     tree: h("div", {
       onclick() {
@@ -654,7 +618,7 @@ testTrees("skip setAttribute for functions", [
   }
 ])
 
-testTrees("update element with dynamic props", [
+testTreeSegue("update element with dynamic props", [
   {
     tree: h("input", {
       type: "text",
@@ -821,3 +785,39 @@ test("event bubling", done => {
     }
   })
 })
+
+function testTreeSegue(name, trees) {
+  test(name, done => {
+    app({
+      root: document.body,
+      view: (state, actions) =>
+        h(
+          "main",
+          {
+            oncreate: actions.next,
+            onupdate: actions.next
+          },
+          [trees[state.index].tree]
+        ),
+      state: {
+        index: 0
+      },
+      actions: {
+        up(state) {
+          return { index: state.index + 1 }
+        },
+        next(state, actions) {
+          expect(document.body.innerHTML).toBe(
+            `<main>${trees[state.index].html.replace(/\s{2,}/g, "")}</main>`
+          )
+
+          if (state.index === trees.length - 1) {
+            return done()
+          }
+
+          actions.up()
+        }
+      }
+    })
+  })
+}

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -2,7 +2,7 @@ import { h } from "../src"
 
 test("empty vnode", () => {
   expect(h("div")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: []
   })
@@ -10,13 +10,13 @@ test("empty vnode", () => {
 
 test("vnode with a single child", () => {
   expect(h("div", {}, ["foo"])).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo"]
   })
 
   expect(h("div", {}, "foo")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo"]
   })
@@ -24,24 +24,24 @@ test("vnode with a single child", () => {
 
 test("positional String/Number children", () => {
   expect(h("div", {}, "foo", "bar", "baz")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo", "bar", "baz"]
   })
 
   expect(h("div", {}, 1, "foo", 2, "baz", 3)).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["1", "foo", "2", "baz", "3"]
   })
 
   expect(h("div", {}, "foo", h("div", {}, "bar"), "baz", "quux")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: [
       "foo",
       {
-        tag: "div",
+        type: "div",
         props: {},
         children: ["bar"]
       },
@@ -61,7 +61,7 @@ test("vnode with props", () => {
   }
 
   expect(h("div", props, "baz")).toEqual({
-    tag: "div",
+    type: "div",
     props,
     children: ["baz"]
   })
@@ -69,7 +69,7 @@ test("vnode with props", () => {
 
 test("skip null and Boolean children", () => {
   const expected = {
-    tag: "div",
+    type: "div",
     props: {},
     children: []
   }
@@ -83,17 +83,17 @@ test("components", () => {
   const Component = (props, children) => h("div", props, children)
 
   expect(h(Component, { id: "foo" }, "bar")).toEqual({
-    tag: "div",
+    type: "div",
     props: { id: "foo" },
     children: ["bar"]
   })
 
   expect(h(Component, { id: "foo" }, [h(Component, { id: "bar" })])).toEqual({
-    tag: "div",
+    type: "div",
     props: { id: "foo" },
     children: [
       {
-        tag: "div",
+        type: "div",
         props: { id: "bar" },
         children: []
       }
@@ -102,10 +102,11 @@ test("components", () => {
 })
 
 test("component with no props adds default props", () => {
-  const Component = ({ name = "world" }, children) => h("div", {}, "Hello " + name)
+  const Component = ({ name = "world" }, children) =>
+    h("div", {}, "Hello " + name)
 
   expect(h(Component)).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["Hello world"]
   })

--- a/test/hydration.test.js
+++ b/test/hydration.test.js
@@ -6,43 +6,37 @@ beforeEach(() => {
   document.body.innerHTML = ""
 })
 
-test("hydrate without explicit root", done => {
-  const body = `<main><p>foo</p></main>`
+testHydration(
+  "hydrate without root",
+  `<main><p>foo</p></main>`,
+  [h("p", {}, "foo")],
+  null
+)
 
-  document.body.innerHTML = body
+testHydration(
+  "hydrate with root",
+  `<div id="app"><main><p>foo</p></main></div>`,
+  [h("p", {}, "foo")],
+  "app"
+)
 
-  app({
-    view: state =>
-      h(
-        "main",
-        {
-          onupdate() {
-            expect(document.body.innerHTML).toBe(body)
-            done()
-          }
-        },
-        [h("p", {}, "foo")]
-      )
+function testHydration(name, ssrBody, children, withRoot) {
+  test(name, done => {
+    document.body.innerHTML = ssrBody
+
+    app({
+      root: withRoot && document.getElementById(withRoot),
+      view: state =>
+        h(
+          "main",
+          {
+            onupdate() {
+              expect(document.body.innerHTML).toBe(ssrBody)
+              done()
+            }
+          },
+          children
+        )
+    })
   })
-})
-
-test("hydrate with root", done => {
-  const body = `<div id="app"><main><p>foo</p></main></div>`
-
-  document.body.innerHTML = body
-
-  app({
-    root: document.getElementById("app"),
-    view: state =>
-      h(
-        "main",
-        {
-          onupdate() {
-            expect(document.body.innerHTML).toBe(body)
-            done()
-          }
-        },
-        [h("p", {}, "foo")]
-      )
-  })
-})
+}

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,26 @@
+import { h, app } from "../src"
+
+window.requestAnimationFrame = setTimeout
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+test("init", done => {
+  app({
+    init(state, actions) {
+      expect(actions.up().value).toBe(2)
+      done()
+    },
+    state: {
+      value: 1
+    },
+    actions: {
+      up(state) {
+        return {
+          value: state.value + 1
+        }
+      }
+    }
+  })
+})

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -9,11 +9,18 @@ beforeEach(() => {
 test("init", done => {
   app({
     init(state, actions) {
-      expect(actions.up().value).toBe(2)
+      expect(state).toEqual({
+        value: 0
+      })
+
+      expect(actions.up()).toEqual({
+        value: 1
+      })
+
       done()
     },
     state: {
-      value: 1
+      value: 0
     },
     actions: {
       up(state) {

--- a/test/modules.test.js
+++ b/test/modules.test.js
@@ -1,0 +1,29 @@
+import { h, app } from "../src"
+
+window.requestAnimationFrame = setTimeout
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+test("modules", done => {
+  const foo = {
+    state: {
+      value: 0
+    },
+    actions: {
+      up(state, actions) {
+        return { value: state.value + 1 }
+      }
+    }
+  }
+
+  app({
+    init(state, actions) {
+      expect(state.foo.value).toBe(0)
+      expect(actions.foo.up().value).toBe(1)
+      done()
+    },
+    modules: { foo }
+  })
+})

--- a/test/modules.test.js
+++ b/test/modules.test.js
@@ -8,20 +8,70 @@ beforeEach(() => {
 
 test("modules", done => {
   const foo = {
+    init(state) {
+      expect(state).toEqual({
+        value: 0,
+        bar: {
+          text: "hello"
+        }
+      })
+    },
     state: {
       value: 0
     },
     actions: {
-      up(state, actions) {
+      up(state) {
         return { value: state.value + 1 }
+      }
+    },
+    modules: {
+      bar: {
+        init(state) {
+          expect(state).toEqual({
+            text: "hello"
+          })
+        },
+        state: {
+          text: "hello"
+        },
+        actions: {
+          change(state) {
+            return { text: "hola" }
+          }
+        }
       }
     }
   }
 
   app({
     init(state, actions) {
-      expect(state.foo.value).toBe(0)
-      expect(actions.foo.up().value).toBe(1)
+      expect(state).toEqual({
+        foo: {
+          value: 0,
+          bar: {
+            text: "hello"
+          }
+        }
+      })
+
+      expect(actions.foo.up()).toEqual({
+        foo: {
+          value: 1,
+          bar: {
+            text: "hello"
+          }
+        }
+      })
+
+      expect(actions.foo.bar.change()).toEqual({
+        foo: {
+          value: 1,
+          bar: {
+            text: "hola"
+          }
+        }
+      })
+
       done()
     },
     modules: { foo }

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -56,7 +56,7 @@ const initialState: State = {
   module1: module1InitialState,
   module2: module2InitialState,
   unused2: {
-    foo: 'bar'
+    foo: "bar"
   }
 }
 
@@ -90,6 +90,6 @@ const appActions = app<State, Actions>({
       </p>
     </main>
   ),
-  actions,  
+  actions,
   root: document.getElementById("app")
 })


### PR DESCRIPTION
## tl;dr

- Introduce `init` function (essentially the original `events.load`).
- Introduce `modules`, similar to the old mixins, but without all their issues. See #406 for a full explanation.
  - Modules can have an init function too.
  - Modules can have nested modules.

## Summary

### `init(state, actions) { ... }`

We don't have an elegant way to call any actions, subscribe to global events or kickstart ourselves when our app loads.

```jsx
app({
  init(state, actions) {
    // Subscribe to global events, start timers, fetch resources & more!
  }
})
```

### `modules: { foo, bar, baz  }`

We also need a way to encapsulate code without all the issues mixins had.

```jsx
app({
  modules: { router, whopper, bazinga }
})
```

Desugars into:

```jsx
app({
  init(state, actions) {
    // Close enough. Actual order is non-deterministic. 
    // Also, router, whooper and bazinga `init` function runs BEFORE the top level `init`.
    // This is consistent with sub-modules. Deepest first. Inside-out.

    router.init(state.router, actions.router)
    whopper.init(state.whopper, actions.whopper)
    bazinga.init(state.bazinga, actions.bazinga)
  },
  state: { 
    router: router.state,
    whopper: whopper.state,
    bazinga: bazinga.state,
  },
  actions: { 
    router: router.actions,
    whopper: whopper.actions,
    bazinga: bazinga.actions
  }
})
```

Quoting @zaceno on the difference between mixins and modules and how they fit together with HOAs.

> This actually gets at the core of the problem I saw with mixins (and why I wanted them renamed from plugins as they once were called): they basically served _two_ purposes: either to A) augment hyperapp’s features, or B) to modularize your app. **Now**, modules is only for (B), and we have HOA for (A).


Close #406, #404.