### PR TITLE
Don't lock render before calling view function.

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -7,33 +7,35 @@ beforeEach(() => {
 })
 
 test("throttling", done => {
+  var count = 0
+
   app({
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe("<div>5</div>")
-            done()
-          }
-        },
-        state.value
-      ),
+    view(state, actions) {
+      if (0 >= count) {
+        actions.fire()
+      }
+
+      count += 1
+
+      return h("div", {}, state.value)
+    },
     state: {
-      value: 1
+      value: "foo"
     },
     actions: {
-      up(state) {
-        return {
-          value: state.value + 1
-        }
+      render(state) {
+        return state
       },
       fire(state, actions) {
-        actions.up()
-        actions.up()
-        actions.up()
-        actions.up()
+        actions.render()
+        actions.render()
+        actions.render()
       }
     }
   }).fire()
+
+  setTimeout(() => {
+    expect(count).toBe(2)
+    done()
+  }, 10)
 })


### PR DESCRIPTION
Basically any actions called inside the view function or inside "functions called inside the view" (e.g., Components) can invalidate the state, and when the view function returns, the state is left "out of sync" with the new vnode.

The idea is to compute the vnode, but before patching the DOM, determine if one or more actions were called (i.e., detect if a re-render was scheduled) and if that's the case return early (don't patch, since render will be called again soon anyway), otherwise proceed as usual.

Fix #424.