### PR TITLE
Add curried API for actions data

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -69,9 +69,11 @@ export function app(props, container) {
     Object.keys(source || {}).map(function(i) {
       if (typeof source[i] === "function") {
         actions[i] = function(data) {
-          return typeof (data = source[i](state, actions, data)) === "function"
-            ? data(update)
-            : update(data)
+          return typeof (data = source[i](state, actions)) !== "function"
+            ? update(data)
+            : typeof (data = data.apply(null, arguments)) !== "function"
+              ? update(data)
+              : data(update)
         }
       } else {
         initActions(state[i] || (state[i] = {}), (actions[i] = {}), source[i])

--- a/src/app.js
+++ b/src/app.js
@@ -69,11 +69,11 @@ export function app(props, container) {
     Object.keys(source || {}).map(function(i) {
       if (typeof source[i] === "function") {
         actions[i] = function(data) {
-          return typeof (data = source[i](state, actions)) !== "function"
-            ? update(data)
-            : typeof (data = data.apply(null, arguments)) !== "function"
-              ? update(data)
-              : data(update)
+          return typeof (data = source[i](state, actions)) === "function"
+            ? typeof (data = data.apply(0, arguments)) === "function"
+              ? data(update)
+              : update(data)
+            : update(data)
         }
       } else {
         initActions(state[i] || (state[i] = {}), (actions[i] = {}), source[i])

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -33,10 +33,19 @@ test("slices", done => {
     actions: {
       foo: {
         bar: {
-          baz(state, actions, data) {
-            expect(state).toEqual({ baz: "minimal baz" })
-            expect(data).toBe("foo.bar.baz")
-            return { baz: "only the baz will do" }
+          baz(state, actions) {
+            return data => {
+              expect(state).toEqual({ baz: "minimal baz" })
+              expect(data).toBe("foo.bar.baz")
+              return { baz: "only the baz will do" }
+            }
+          },
+          buz(state, actions) {
+            return (data1, data2, data3) => {
+              expect(data1).toBe("foo")
+              expect(data2).toBe("bar")
+              expect(data3).toBe("baz")
+            }
           }
         }
       },
@@ -49,6 +58,7 @@ test("slices", done => {
   })
 
   actions.foo.bar.baz("foo.bar.baz")
+  actions.foo.bar.buz("foo", "bar", "baz")
   actions.fizz.buzz.fizzbuzz()
 })
 
@@ -98,15 +108,17 @@ test("async updates", done => {
       value: 2
     },
     actions: {
-      up(state, actions, byNumber) {
-        return {
+      up(state, actions) {
+        return byNumber => ({
           value: state.value + byNumber
-        }
-      },
-      upAsync(state, actions, byNumber) {
-        mockDelay().then(() => {
-          actions.up(byNumber)
         })
+      },
+      upAsync(state, actions) {
+        return byNumber => {
+          mockDelay().then(() => {
+            actions.up(byNumber)
+          })
+        }
       }
     }
   }).upAsync(1)
@@ -132,8 +144,8 @@ test("thunks", done => {
       value: 3
     },
     actions: {
-      upAsync(state, actions, data) {
-        return update => {
+      upAsync(state, actions) {
+        return data => update => {
           mockDelay().then(() => {
             update({ value: state.value + data })
           })
@@ -163,8 +175,8 @@ test("thunks", done => {
       value: 4
     },
     actions: {
-      upAsync(state, actions, data) {
-        return update => {
+      upAsync(state, actions) {
+        return data => update => {
           mockDelay().then(() => {
             update(state => ({ value: state.value + data }))
           })


### PR DESCRIPTION
Some weeks ago, we were discussing about the magics behind Hyperapp and the ways to be more transparent. Here I made a proposition https://github.com/hyperapp/hyperapp/issues/380#issuecomment-330901225 now this on the way to be a real PR.

To sum up (a long long long war on slack), the proposition is about removing the comfusion regarding the actions you will write/define and the actions you will get/use.

At the moment, you are defining actions that way.
```ts
(state, actions, data) => function
```
But, when it will be time to use you action, you will use action with this signature
```ts
(data) => function
```
And I am pretty sure here is a lot of troubles here.

How many times have you answered a question about someone trying to use their actions that way ?
```jsx
actions.myaction(state, actions, data)
```

This is why I am coming at you with this proposition : 
```ts
(state, actions) => (data) => function
```

The following will be better on three points : 
1. The api will look the same all arround the app/entries 
```ts
(state, actions) => function
```
2. Users will understand more easily what they need to use
```ts
(data) => function
```
3. Actions are now able to use more than 1 argument
```ts
(foo, bar, baz, ... fizz) => function
```

in 11 bytes

---

```jsx
app({
  state: {
    count: 0
  },
  view: (state, actions) =>
    <main>
      <h1>
        {state.count}
      </h1>
      <button onclick={() => actions.subLater(1, 3000)} disabled={state.count <= 0}>ー (3 sec)</button>
      <button onclick={() => actions.sub(1)} disabled={state.count <= 0}>ー (now)</button>
      <button onclick={() => actions.add(1)}>＋ (now)</button>
      <button onclick={() => actions.addLater(1, 3000)}>＋ (3 sec)</button>
    </main>,
  actions: {
    sub: (state, actions) => (value) => ({ count: state.count - value }),
    add: (state, actions) => (value) => ({ count: state.count + value }),
    subLater: (state, actions) => (value, time) => update => {
      setTimeout(() => {
        update(state => state.count <= 0 ? {} : { count: state.count - value })
      }, time)
    },
    addLater: (state, actions) => (value, time) => update => {
      setTimeout(() => {
        update(state => ({ count: state.count + value }))
      }, time)
    }
  }
})
```

Now time for questions :smiley: 