### PR TITLE
Allow app to be loaded as a ES6 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "^21.2.1",
     "prettier": "~1.7.4",
     "rollup": "^0.50.0",
-    "typescript": "^2.5.2",
+    "typescript": "~2.5.2",
     "uglify-js": "^2.7.5"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import { h } from "./h"
+import { h } from "./h.js"
 
 export function app(props, container) {
   var root = (container = container || document.body).children[0]


### PR DESCRIPTION
This is the only change needed to be able to use hyperapp as a ES6 module in a browser, while it still remains compatible with node and bundlers.

It changes the path to the h file to "./h" from "./h.js", since browsers will not auto-append the .js suffix like many bundlers/transpilers do.