### PR TITLE
Remove unused variable

### DIFF
--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -655,7 +655,7 @@ testTreeSegue("don't touch textnodes if equal", [
     html: `<main>foobar</main>`
   }
 ])
-var xx = 0
+
 function testTreeSegue(name, trees) {
   test(name, done => {
     app({


### PR DESCRIPTION
I believe a cheeky var managed to elude linting. She's gone now.