### PR TITLE
Update types for 0.16 and typescript 2.6.1

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -41,7 +41,7 @@ export type VNodeChildren =
  * @param children  The children of the VNode
  *
  * @memberOf [VDOM]
-*/
+ */
 export function h<Props>(
   type: Component<Props> | string,
   props?: Props,
@@ -64,10 +64,10 @@ export type InternalAction<State, Actions> =
  *
  * @memberOf [App]
  */
-export type InternalActions<State, Actions, OwnActions = Actions> = {
-  [P in keyof OwnActions]:
+export type InternalActions<State, Actions> = {
+  [P in keyof Actions]:
     | InternalAction<State, Actions>
-    | InternalActions<any, any>
+    | InternalActions<any, Actions[P]>
 }
 
 /** The view function.
@@ -78,61 +78,16 @@ export interface View<State, Actions> {
   (state: State, actions: Actions): VNode<{}>
 }
 
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T]
-
-type Sub<A, B> = { [P in keyof A]: A[P] } & { [P in keyof B]: never }
-
-/** Definition for a single module: a self-contained set of actions that operates on a state tree.
- *
- * OwnState and OwnActions may be set to ensure that the initial state and all actions are implemented.
- *
- * @param State The full state of the module including sub-modules
- * @param Actions The actions of the module including sub-modules
- * @param OwnState Optional, if set, the state of this module excluding sub-modules
- *                 defaults to full state
- * @param OwnActions Optional, if set, the actions of this module excluding sub-modules
- *                   defaults to full actions
- *
- * @memberOf [App]
- */
-export interface Module<
-  State,
-  Actions,
-  OwnState = State,
-  OwnActions = Actions
-> {
-  state?: OwnState
-  actions?: InternalActions<State, Actions, OwnActions>
-  // Should be Modules<State - OwnState, Actions - OwnActions> - see https://github.com/Microsoft/TypeScript/issues/4183
-  modules?: Modules<any, any>
-}
-
-/** The map of modules indexed by state slice.
- *
- * @memberOf [App]
- */
-export type Modules<State, Actions> = {
-  [S in keyof State]?: Module<State[S], Actions[S & keyof Actions]>
-}
-
 /** The props object that serves as an input to app().
  *
  * @param State The full state of the module including sub-modules
  * @param Actions The actions of the module including sub-modules
- * @param OwnState Optional, if set, the state of this module excluding sub-modules
- *                 defaults to partial state
- * @param OwnActions Optional, if set, the actions of this module excluding sub-modules
- *                   defaults to partial actions
  *
  * @memberOf [App]
  */
-export interface AppProps<
-  State,
-  Actions,
-  OwnState = State,
-  OwnActions = Actions
-> extends Module<State, Actions, OwnState, OwnActions> {
+export interface AppProps<State, Actions> {
+  state?: State
+  actions?: InternalActions<State, Actions>
   view?: View<State, Actions>
 }
 
@@ -140,15 +95,11 @@ export interface AppProps<
  *
  * @param State The full state of the module including sub-modules
  * @param Actions The actions of the module including sub-modules
- * @param OwnState Optional, if set, the state of this module excluding sub-modules
- *                 defaults to partial state
- * @param OwnActions Optional, if set, the actions of this module excluding sub-modules
- *                   defaults to partial actions
  *
  * @memberOf [App]
  */
-export function app<State, Actions, OwnState = State, OwnActions = Actions>(
-  app: AppProps<State, Actions, OwnState, OwnActions>,
+export function app<State, Actions>(
+  app: AppProps<State, Actions>,
   container?: HTMLElement | null
 ): Actions
 

--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -56,7 +56,7 @@ export function h<Props>(
  */
 export type ActionResult<State> = Partial<State> | Promise<any> | null | void
 
-export type InternalAction<State, Actions> =
+export type MyAction<State, Actions> =
   | ((state: State, actions: Actions) => (data: any) => ActionResult<State>)
   | ((state: State, actions: Actions) => ActionResult<State>)
 
@@ -64,10 +64,8 @@ export type InternalAction<State, Actions> =
  *
  * @memberOf [App]
  */
-export type InternalActions<State, Actions> = {
-  [P in keyof Actions]:
-    | InternalAction<State, Actions>
-    | InternalActions<any, Actions[P]>
+export type MyActions<State, Actions> = {
+  [P in keyof Actions]: MyAction<State, Actions> | MyActions<any, Actions[P]>
 }
 
 /** The view function.
@@ -87,7 +85,7 @@ export interface View<State, Actions> {
  */
 export interface AppProps<State, Actions> {
   state?: State
-  actions?: InternalActions<State, Actions>
+  actions?: MyActions<State, Actions>
   view?: View<State, Actions>
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jest": "^21.2.1",
     "prettier": "~1.8.2",
     "rollup": "^0.51.2",
-    "typescript": "~2.5.2",
+    "typescript": "~2.6.1",
     "uglify-js": "^2.7.5"
   }
 }

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -15,7 +15,7 @@ const counterState: CounterState = {
   count: 0
 }
 
-const counterActions: Hyperapp.InternalActions<CounterState, CounterActions> = {
+const counterActions: Hyperapp.MyActions<CounterState, CounterActions> = {
   sub: (state, actions) => ({ count: state.count - 1 }),
   add: (state, actions) => (value: number) => ({
     count: state.count + value
@@ -49,7 +49,7 @@ const module1State: Module1State = {
   count: 0
 }
 
-const module1Actions: Hyperapp.InternalActions<Module1State, Module1Actions> = {
+const module1Actions: Hyperapp.MyActions<Module1State, Module1Actions> = {
   counter: counterActions,
   sub: (state, actions) => ({ count: state.count - 1 }),
   add: (state, actions) => (value: number) => ({
@@ -79,7 +79,7 @@ interface AsyncActions {
 
 const asyncState: AsyncState = {}
 
-const asyncActions: Hyperapp.InternalActions<AsyncState, AsyncActions> = {
+const asyncActions: Hyperapp.MyActions<AsyncState, AsyncActions> = {
   setResult: (state, actions) => (value: number | Error) => ({ value }),
   fetch: (state, actions) => (url: string) =>
     fetch(url)
@@ -130,7 +130,7 @@ interface Actions {
   add(value: number): Partial<State>
 }
 
-const actions: Hyperapp.InternalActions<State, Actions> = {
+const actions: Hyperapp.MyActions<State, Actions> = {
   module1: module1Actions,
   async: asyncActions,
   add: (state, actions) => (value: number) => ({


### PR DESCRIPTION
This is a big update for the types:
 - support for HA 0.16
 - support for typescript 2.6.1
 - simplifications of the types
