### PR TITLE
Virtual Node Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ actions: {
 The view describes your user interface as a function of the [state](#state).
 Bind user events and [actions](#actions) together to create interactive applications. The view function is called every time we need to re-render the application due to state changes.
 
-The `h()` function returns a virtual node, an object that describes a DOM tree. Hyperapp consumes this object to update the DOM.
+The `h()` function returns a [virtual node](vnodes.md), an object that describes a DOM tree. Hyperapp consumes this object to update the DOM.
 
 Popular alternatives to the built-in `h()` function include [JSX](https://facebook.github.io/jsx/), [lit-html](https://github.com/PolymerLabs/lit-html), [hyperx](https://github.com/choojs/hyperx), [t7](https://github.com/trueadm/t7) and [@hyperapp/html](https://github.com/hyperapp/html).
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,6 +1,6 @@
 # Components
 
-A component is a pure function that returns a virtual node. Unlike a view, they are not pre-wired to your application state or actions. Components are reusable blocks of code that encapsulate markup, styles and behaviors that belong together.
+A component is a pure function that returns a [virtual node](vnodes.md). Unlike a view, they are not pre-wired to your application state or actions. Components are reusable blocks of code that encapsulate markup, styles and behaviors that belong together.
 
 [Try it Online](https://codepen.io/hyperapp/pen/zNxRLy)
 

--- a/docs/vnodes.md
+++ b/docs/vnodes.md
@@ -1,0 +1,56 @@
+# Virtual Nodes
+
+A virtual node is a JavaScript object that represents an element in the DOM tree.
+
+```js
+{
+  type: "div",
+  props: {
+    id: "app"
+  },
+  children: [{
+    tag: "h1",
+    data: {},
+    children: ["Hi."]
+  }]
+}
+```
+
+To create a virtual node, use the `h` function.
+
+```js
+const node = h("div", { id: "app" }, [
+  h("h1", {}, "Hi.")
+])
+```
+
+Instead of using the built-in `h()` function you may use [JSX](https://facebook.github.io/jsx/), [lit-html](https://github.com/PolymerLabs/lit-html), [hyperx](https://github.com/choojs/hyperx), [t7](https://github.com/trueadm/t7) or [@hyperapp/html](https://github.com/hyperapp/html).
+
+```jsx
+const node = (
+  <div id="app">
+    <h1>Hi.</h1>
+  </div>
+)
+```
+
+Virtual node props may include any valid [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes) or [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute) attributes, [DOM](https://developer.mozilla.org/en-US/docs/Web/Events), [lifecycle events](lifecycle.md), and [keys](keys.md).
+
+```jsx
+const button = (
+  <button
+    class="ui button"
+    tabindex={0}
+    style={{
+      fontSize: "3em"
+    }}
+    onclick={() => {
+      // ...
+    }}
+  >
+    Click Me
+  </button>
+)
+```
+
+A function that returns a virtual node is known as a [component](components.md).


### PR DESCRIPTION
I was looking for a writeup on all the `props` that are allowed on vnodes, and after some archeology I remembered that this was already written up all the way back in the days of 0.12.1: https://github.com/hyperapp/hyperapp/blob/0.12.1/docs/vnodes.md

If we decide not to keep all the gory details from this, I'd like to at least include this useful tidbit somewhere:

> Virtual node props may include any valid [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes) or [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute) attributes, [DOM](https://developer.mozilla.org/en-US/docs/Web/Events), [lifecycle events](lifecycle.md), and [keys](keys.md).