### PR TITLE
Point-free style actions API: D=>S=>A 🍛

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ app({
   state: {
     count: 0
   },
-  view: (state, actions) =>
+  view: state => actions =>
     <main>
       <h1>{state.count}</h1>
       <button onclick={actions.down}>–</button>
       <button onclick={actions.up}>+</button>
     </main>,
   actions: {
-    down: state => ({ count: state.count - 1 }),
-    up: state => ({ count: state.count + 1 })
+    down: () => state => ({ count: state.count - 1 }),
+    up: () => state => ({ count: state.count + 1 })
   }
 })
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,21 +33,25 @@ app({
   state: {
     count: 0
   },
-  view: (state, actions) => (
+  view: state => actions => (
     h("main", {}, [
       h("h1", {}, state.count),
       h("button", {
-        onclick: actions.down,
+        onclick() {
+          actions.down(1)
+        },
         disabled: state.count <= 0
       }, "–"),
       h("button", {
-        onclick: actions.up
+        onclick() {
+          actions.up(1)
+        },
       }, "+")
     ])
   ),
   actions: {
-    down: state => ({ count: state.count - 1 }),
-    up: state => ({ count: state.count + 1 })
+    down: n => state => ({ count: state.count - n }),
+    up: n => state => ({ count: state.count + n })
   }
 })
 
@@ -86,20 +90,12 @@ Actions are used to manipulate the [state](#state). If your application consumes
 
 ```jsx
 actions: {
-  down: state => ({ count: state.count - 1 }),
-  up: state => ({ count: state.count + 1 })
+  down: n => state => ({ count: state.count - n }),
+  up: n => state => ({ count: state.count + n })
 }
 ```
 
 Actions must never mutate the state directly. Returning a new state from an action updates the current state and schedules a re-render.
-
-You can also pass arguments to actions by returning a function.
-
-```jsx
-actions: {
-  upWithValue: state => value => ({ count: state.count + value })
-}
-```
 
 ### View
 
@@ -123,21 +119,25 @@ app({
   state: {
     count: 0
   },
-  view: (state, actions) => (
+  view: state => actions => (
     main([
       h1(state.count),
       button({
-        onclick: actions.down,
+        onclick() {
+          actions.down(1)
+        },
         disabled: state.count <= 0
       }, "–"),
       button({
-        onclick: actions.up
+        onclick() {
+          actions.up(1)
+        },
       }, "+")
     ])
   ),
   actions: {
-    down: state => ({ count: state.count - 1 }),
-    up: state => ({ count: state.count + 1 })
+    down: n => state => ({ count: state.count - n }),
+    up: n => state => ({ count: state.count + n })
   }
 })
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -5,52 +5,38 @@ A component is a pure function that returns a [virtual node](vnodes.md). Unlike 
 [Try it Online](https://codepen.io/hyperapp/pen/zNxRLy)
 
 ```jsx
-function TodoItem({ id, value, done, toggle }) {
-  return (
-    <li
-      class={done && "done"}
-      onclick={e =>
-        toggle({
-          value: done,
-          id: id
-        })}
-    >
-      {value}
-    </li>
-  )
-}
+const TodoItem = ({ id, value, done, toggle }) => (
+  <li
+    class={done && "done"}
+    onclick={e =>
+      toggle({
+        value: done,
+        id: id
+      })
+    }
+  >
+    {value}
+  </li>
+)
 
-function mainView(state, actions) {
-  return (
-    <div>
-      <h1>Todo</h1>
-      <ul>
-        {state.todos.map(({ id, value, done }) => (
-          <TodoItem
-            id={id}
-            value={value}
-            done={done}
-            toggle={actions.toggle}
-          />
-        ))}
-      </ul>
-    </div>
-  )
-}
+const mainView = state => actions => (
+  <div>
+    <h1>Todo</h1>
+    <ul>
+      {state.todos.map(({ id, value, done }) => (
+        <TodoItem id={id} value={value} done={done} toggle={actions.toggle} />
+      ))}
+    </ul>
+  </div>
+)
 ```
 
 If you don't know all the properties that you want to place in a component ahead of time, you can use the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator).
 
 ```jsx
-function TodoList({ todos, toggle }) {
-  return (
-    <ul>{todos.map(todo =>
-      <TodoItem {...todo}
-        toggle={toggle}
-      />)}
-    </ul>
-  )
-}
+const TodoList = ({ todos, toggle }) => (
+  <ul>{todos.map(todo => <TodoItem {...todo} toggle={toggle} />)}</ul>
+)
 ```
 
 Note that when using JSX, components [must be capitalized](https://facebook.github.io/react/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized) or contain a `.` in their name.
@@ -60,25 +46,17 @@ Note that when using JSX, components [must be capitalized](https://facebook.gith
 Components receive children elements in the second argument.
 
 ```jsx
-function Box({ color }, children) {
-  return (
-    <div class={`box box-${color}`}>
-      {children}
-    </div>
-  )
-}
+const Box = ({ color }, children) => (
+  <div class={`box box-${color}`}>{children}</div>
+)
 ```
 
 This lets you and other components pass arbitrary children down to them.
 
 ```jsx
-function HelloBox({ name }) {
-  return (
-    <Box color="green">
-      <h1 class="title">
-        Hello, {name}!
-      </h1>
-    </Box>
-  )
-}
+const HelloBox = ({ name }) => (
+  <Box color="green">
+    <h1 class="title">Hello, {name}!</h1>
+  </Box>
+)
 ```

--- a/docs/countdown-timer.md
+++ b/docs/countdown-timer.md
@@ -21,23 +21,22 @@ const { tick } = app({
     count: SECONDS,
     paused: true
   },
-  view: (state, actions) =>
+  view: state => actions => (
     <main>
-      <h1>
-        {humanizeTime(state.count)}
-      </h1>
+      <h1>{humanizeTime(state.count)}</h1>
 
       <button onclick={actions.toggle}>
         {state.paused ? "START" : "PAUSED"}
       </button>
 
       <button onclick={actions.reset}>RESET</button>
-    </main>,
+    </main>
+  ),
   actions: {
-    toggle: state => ({ paused: !state.paused }),
-    reset: state => ({ count: SECONDS }),
-    drop: state => ({ count: state.count - 1 }),
-    tick: (state, actions) => {
+    toggle: () => state => ({ paused: !state.paused }),
+    reset: () => ({ count: SECONDS }),
+    drop: () => state => ({ count: state.count - 1 }),
+    tick: () => state => actions => {
       if (state.count === 0) {
         actions.reset()
         actions.toggle()

--- a/docs/gif-search.md
+++ b/docs/gif-search.md
@@ -1,6 +1,6 @@
-# Gif Search
+# gif Search
 
-In this example we'll implement a GIF search using the [Giphy API](https://api.giphy.com/) and learn how to update the state asynchronously.
+In this example we'll implement a gif search using the [Giphy API](https://api.giphy.com/) and learn how to update the state asynchronously.
 
 [Try it Online](https://codepen.io/hyperapp/pen/ZeByKv?editors=0010)
 
@@ -8,55 +8,64 @@ In this example we'll implement a GIF search using the [Giphy API](https://api.g
 app({
   state: {
     url: "",
+    query: "",
     isFetching: false
   },
-  view: (state, actions) =>
+  view: state => actions => (
     <main>
       <input
         type="text"
-        placeholder="Type to search..."
-        onkeyup={actions.search}
+        placeholder="Type here..."
+        onkeyup={({ target: { value } }) => {
+          if (value !== state.query) {
+            actions.setQuery(value)
+            if (!state.isFetching) {
+              actions.downloadGif(value)
+            }
+          }
+        }}
+        autofocus
       />
       <div class="container">
         <img
           src={state.url}
-          style={{ display: state.isFetching ? "none" : "block" }}
+          style={{
+            display: state.isFetching || state.url === "" ? "none" : "block"
+          }}
         />
       </div>
-    </main>,
+    </main>
+  ),
   actions: {
-    search: (state, actions) => ({ target }) => {
-      const text = target.value
-
-      if (state.isFetching || text === "") {
-        return { url: "" }
-      }
-
-      actions.toggleFetching()
-
-      fetch(`//api.giphy.com/v1/gifs/search?q=${text}&api_key=${GIPHY_API_KEY}`)
-        .then(data => data.json())
-        .then(({ data }) => {
-          actions.toggleFetching()
-          data[0] && actions.setUrl(data[0].images.original.url)
-        })
+    downloadGif: query => state => async actions => {
+      actions.toggleFetching(true)
+      actions.setUrl(
+        await fetch(
+          `//api.giphy.com/v1/gifs/search?q=${query}&api_key=${GIPHY_API_KEY}`
+        )
+          .then(data => data.json())
+          .then(({ data }) => (data[0] ? data[0].images.original.url : ""))
+      )
+      actions.toggleFetching(false)
     },
-    setUrl: state => url => ({ url }),
-    toggleFetching: state => ({ isFetching: !state.isFetching })
+    setUrl: url => ({ url }),
+    setQuery: query => ({ query }),
+    toggleFetching: isFetching => ({ isFetching })
   }
 })
 ```
 
-The state consists of two properties: `url`, the GIF URL; and `isFetching` to track when the browser is fetching a new GIF.
+The state consists of three properties: `url`, the url of the gif; `isFetching` to track when the browser is fetching a new gif, and query, what the user has typed into the text input.
 
 ```jsx
 state: {
   url: "",
+  query: "",
   isFetching: false
 }
 ```
 
-The `isFetching` flag is used to hide the GIF while the browser is busy. Without it, the last downloaded GIF would be shown as another one is requested.
+The `isFetching` flag is used to hide the gif while the browser is busy. Without it, the last downloaded gif would be shown as another one is requested.
 
 ```jsx
 style={{
@@ -64,29 +73,29 @@ style={{
 }}
 ```
 
-The view consists of a text input and an `img` element to display the GIF.
+The view consists of a text input and an `img` element to display the gif.
 
-Using `onkeyup` retrieve the input text and call `actions.search` to request a new GIF. If a fetch is pending or the text input is empty exit early.
+Inside `onkeyup` we retrieve the input text and call `actions.setQuery` to update the current search query, then call `actions.downloadGif` to request a new gif. If a fetch is still pending, we skip the action.
 
 ```jsx
-if (state.isFetching || text === "") {
-  return { url: "" }
+if (value !== state.query) {
+  actions.setQuery(value)
+  if (!state.isFetching) {
+    actions.downloadGif(value)
+  }
 }
 ```
 
-Inside `actions.search` use the [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to download a GIF URL from Giphy.
+Inside `actions.downloadGif` we use the [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to download a gif url from Giphy.
 
-When `fetch` is done, we receive the payload with the GIF metadata inside a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+When `fetch` is done, we receive the payload with the gif metadata and call `actions.setUrl` with the value.
 
 ```jsx
-fetch(
-  `//api.giphy.com/v1/gifs/search?q=${text}&api_key=${GIPHY_API_KEY}`
+actions.setUrl(
+  await fetch(
+    `//api.giphy.com/v1/gifs/search?q=${query}&api_key=${GIPHY_API_KEY}`
+  )
+    .then(data => data.json())
+    .then(({ data }) => (data[0] ? data[0].images.original.url : ""))
 )
-  .then(data => data.json())
-  .then(({ data }) => {
-    actions.toggleFetching()
-    data[0] && actions.setUrl(data[0].images.original.url)
-  })
 ```
-
-Finally, call `actions.toggleFetching` to allow further fetch requests to be made and update the state by passing the fetched GIF URL to `actions.setUrl`.

--- a/docs/slices.md
+++ b/docs/slices.md
@@ -8,13 +8,13 @@ State slices address this issue with actions that access a slice of the state tr
 
 ```js
 actions: {
-  hello(state) {
-  // The state is the global `state`.
+  hello: data => state => {
+    // The state is the global `state`.
   },
   foo: {
-    bar: { 
-      howdy(state) {
-      // The state is: `state[foo][bar]`
+    bar: {
+      howdy: data => state => {
+        // The state is: `state[foo][bar]`
       }
     }
   }
@@ -42,7 +42,7 @@ In other words, you had to write something like the following in order to update
 
 ```js
 actions: {
-  updateValue(state) {
+  updateValue: data => state => {
     return {
       foo: {
         bar: {
@@ -74,9 +74,9 @@ You will have a corresponding action inside a namespace that matches the state y
 actions: {
   foo: {
     bar: {
-      updateValue(state) {
+      updateValue: data => state => {
         // State is `state[foo][bar]`
-        return { value: state.value + 1 }
+        return { value: state.value + data }
       }
     }
   }

--- a/docs/tweetbox.md
+++ b/docs/tweetbox.md
@@ -53,14 +53,14 @@ app({
     text: "",
     count: MAX_LENGTH
   },
-  view: (state, actions) =>
+  view: state => actions =>
     <Tweetbox
       text={state.text}
       count={state.count}
       update={e => actions.update(e.target.value)}
     />,
   actions: {
-    update: state => text => ({
+    update: text => state => ({
       text,
       count: state.count + state.text.length - text.length
     })

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -23,7 +23,7 @@ test("sync updates", done => {
         state.value
       ),
     actions: {
-      up: state => ({ value: state.value + 1 })
+      up: () => state => ({ value: state.value + 1 })
     }
   }).up()
 })
@@ -48,8 +48,8 @@ test("async updates", done => {
         state.value
       ),
     actions: {
-      up: state => data => ({ value: state.value + data }),
-      upAsync: (state, actions) => data =>
+      up: data => state => ({ value: state.value + data }),
+      upAsync: data => state => actions =>
         mockDelay().then(() => actions.up(data))
     }
   }).upAsync(1)

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -21,8 +21,8 @@ test("debouncing", done => {
         state.value
       ),
     actions: {
-      up: state => ({ value: state.value + 1 }),
-      fire: (state, actions) => {
+      up: () => state => ({ value: state.value + 1 }),
+      fire: () => state => actions => {
         actions.up()
         actions.up()
         actions.up()
@@ -37,7 +37,7 @@ test("actions in the view", done => {
     state: {
       value: 0
     },
-    view: (state, actions) => {
+    view: state => actions => {
       if (state.value < 1) {
         return actions.up()
       }
@@ -50,7 +50,7 @@ test("actions in the view", done => {
       return h("div", {}, state.value)
     },
     actions: {
-      up: state => ({ value: state.value + 1 })
+      up: () => state => ({ value: state.value + 1 })
     }
   })
 })

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -59,7 +59,7 @@ test("container with mutated host", done => {
       state: {
         value: "foo"
       },
-      view: (state, actions) =>
+      view: state => actions =>
         h(
           "p",
           {
@@ -85,7 +85,7 @@ test("container with mutated host", done => {
           state.value
         ),
       actions: {
-        bar: state => ({ value: "bar" })
+        bar: () => ({ value: "bar" })
       }
     },
     container

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -6,7 +6,7 @@ function testTreeSegue(name, trees) {
       state: {
         index: 0
       },
-      view: (state, actions) =>
+      view: state => actions =>
         h(
           "main",
           {
@@ -16,8 +16,8 @@ function testTreeSegue(name, trees) {
           [trees[state.index].tree]
         ),
       actions: {
-        up: state => ({ index: state.index + 1 }),
-        next: (state, actions) => {
+        up: () => state => ({ index: state.index + 1 }),
+        next: () => state => actions => {
           expect(document.body.innerHTML).toBe(
             `<main>${trees[state.index].html.replace(/\s{2,}/g, "")}</main>`
           )
@@ -688,5 +688,3 @@ testTreeSegue("don't touch textnodes if equal", [
     html: `<main>foobar</main>`
   }
 ])
-
-

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -25,7 +25,7 @@ test("onupdate", done => {
   app({
     state: { value: "foo" },
 
-    view: (state, actions) =>
+    view: state => actions =>
       h(
         "div",
         {
@@ -42,7 +42,7 @@ test("onupdate", done => {
         state.value
       ),
     actions: {
-      repaint: state => ({})
+      repaint: () => ({})
     }
   })
 })
@@ -52,7 +52,7 @@ test("onremove", done => {
     state: {
       value: true
     },
-    view: (state, actions) =>
+    view: state => actions =>
       state.value
         ? h(
             "ul",
@@ -77,7 +77,7 @@ test("onremove", done => {
           )
         : h("ul", {}, [h("li")]),
     actions: {
-      toggle: state => ({ value: !state.value })
+      toggle: () => state => ({ value: !state.value })
     }
   })
 })
@@ -88,7 +88,7 @@ test("event bubling", done => {
     state: {
       value: true
     },
-    view: (state, actions) =>
+    view: state => actions =>
       h(
         "main",
         {
@@ -129,7 +129,7 @@ test("event bubling", done => {
         ]
       ),
     actions: {
-      toggle: state => ({ value: !state.value })
+      toggle: () => state => ({ value: !state.value })
     }
   })
 })

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -35,7 +35,7 @@ test("modules", done => {
       value: true
     },
     actions: {
-      change: state => ({ value: !state.value })
+      change: () => state => ({ value: !state.value })
     }
   }
 
@@ -45,7 +45,7 @@ test("modules", done => {
       bar: bar.state
     },
     actions: {
-      up: state => ({ value: !state.value }),
+      up: () => state => ({ value: !state.value }),
       bar: bar.actions
     }
   }
@@ -54,7 +54,7 @@ test("modules", done => {
     state: { foo: foo.state },
     actions: {
       foo: foo.actions,
-      getState: state => state
+      getState: () => state => state
     }
   })
 


### PR DESCRIPTION
## What's new?

### Change actions signature
```js
actions: {
  setFoo: value => ({ foo: value }),
  multiplyFoo: value => state => ({ foo: state.foo * value }),
  calculateFoobar: value => state => actions => {
    // ...
  }
}
```

### Change view signature

```jsx
view: state => <h1>Hello</h1> 
```

```jsx
view: state => actions => <button onclick={actions.hello}>Hello</button>
```

## Background

When this idea was first suggested by @lukejacksonn, I was hesitant because it meant parting ways with what I felt was the "perfect" signature `(state, actions)`, also seen in the view. 

I was also unsure of the hanging `()` parens, like in the following example.

```jsx
actions: {
  toggle: () => state => ({ paused: !state.paused }),
  reset: () => ({ count: SECONDS }),
  drop: () => state => ({ count: state.count - 1 }),
  tick: () => state => actions => {
    if (state.count === 0) {
      actions.reset()
      actions.toggle()
    } else if (!state.paused) {
      actions.drop()
    }
  }
}
```

But then I asked myself: if `toggle: () => state => ({ paused: !state.paused })` bothers you, how do you deal with `actions.toggle()`? 

To someone looking at this code for the first time, it will be self-explanatory that toggle, reset and drop do not receive a payload, as they are called **without** arguments.

On the other hand, how do you explain calling `toggle: state => ({ paused: !state.paused })` as `actions.toggle()` in the current API? It's nice not having to write the parens when the action does not receive a payload, but it's completely magical why it works.

