### PR TITLE
Format for all!

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle": "rollup -i src/index.js -o dist/hyperapp.js -m -f umd -n hyperapp",
     "minify": "uglifyjs dist/hyperapp.js -o dist/hyperapp.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --in-source-map dist/hyperapp.js.map --source-map dist/hyperapp.js.map",
     "prepare": "npm run build",
-    "format": "prettier --semi false --write 'src/**/*.js' '{,test/ts/}*.{ts,tsx}'",
+    "format": "prettier --semi false --write \"src/**/*.js\" \"{,test/ts/}*.{ts,tsx}\"",
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {


### PR DESCRIPTION
The `npm run format` command gives this error when run by a developer unfortunate enough to be developing on Windows:

```console
> prettier --semi false --write 'src/**/*.js' '{,test/ts/}*.{ts,tsx}'

No matching files. Patterns tried: 'src/**/*.js' '{,test/ts/}*.{ts,tsx}' !**/node_modules/** !./node_modules/**
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! hyperapp@0.16.0 format: `prettier --semi false --write 'src/**/*.js' '{,test/ts/}*.{ts,tsx}'`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the hyperapp@0.16.0 format script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

It appears single quote strings for command line arguments doesn't work cross-platform. Double quotes to the rescue! 😂 