### PR TITLE
Update the new API with respect to the View type

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -76,9 +76,11 @@ export type MyActions<State, Actions> = {
  *
  * @memberOf [App]
  */
-export interface View<State, Actions> {
-  (state: State, actions: Actions): VNode<{}>
-}
+export type View<State, Actions> = (
+  state: State
+) =>
+  | ((actions: Actions) => VNode<{}>)
+  | VNode<{}>
 
 /** The props object that serves as an input to app().
  *


### PR DESCRIPTION
The view is converted from `(state, actions) => VNode` to `state => actions => VNode`

I believe it should be like this. Please don't pin me down on it, as I'm not that good with Type definitions ;)