### PR TITLE
actively supported versions of Node.js: 6, 8, and 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - "6"
   - "8"
-  - "7"
+  - "9"
 
 env:
   - NODE_ENV=development


### PR DESCRIPTION
References #473

Update Travis Node Versions to Supported Versions 🎉 