### PR TITLE
Typing update for View & VNodes

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -9,7 +9,7 @@ export as namespace Hyperapp
 export interface VNode<Props> {
   type: string
   props: Props
-  children: VNodeChild<{} | null>[]
+  children: VNodeChild<object | null>[]
 }
 
 /** In the VDOM a Child could be either a VNode or a string
@@ -23,7 +23,7 @@ export type VNodeChild<Props> = VNode<Props> | string
  * @memberOf [VDOM]
  */
 export interface Component<Props> {
-  (props: Props, children: VNodeChild<{} | null>[]): VNode<{}>
+  (props: Props, children: VNodeChild<object | null>[]): VNode<{}>
 }
 
 /**The type for the children parameter accepted by h().
@@ -31,8 +31,8 @@ export interface Component<Props> {
  * @memberOf [VDOM]
  */
 export type VNodeChildren =
-  | Array<VNodeChild<{} | null> | number>
-  | VNodeChild<{} | null>
+  | Array<VNodeChild<object | null> | number>
+  | VNodeChild<object | null>
   | number
 
 /** The soft way to create a VNode
@@ -78,9 +78,7 @@ export type MyActions<State, Actions> = {
  */
 export type View<State, Actions> = (
   state: State
-) =>
-  | ((actions: Actions) => VNode<{}>)
-  | VNode<{}>
+) => ((actions: Actions) => VNode<object | null>) | VNode<object | null>
 
 /** The props object that serves as an input to app().
  *


### PR DESCRIPTION
I've started trying out Hyperapp with Typescript, and noticed a couple issues.

The current typing for the app's view parameter (`export type View`) did not allow `null` for the props, so this was giving compiler errors:
```js
app({
  view: () => h('div', null, 'Test')
})
```

I also noticed you were allowed to put weird things like numbers in the props of vnodes.  This wasn't giving any errors at compilation time. 
```js
app({
  view: () => h('div', 1, 'Test')
})
```
Since JS considers nearly everything an object, that means that `{}` is not a very specific type.  Typescript 2.2 they added `object`, which is more specific, referring to non-primitive types.  It still won't prevent you from passing an array, but it's a little better.  This article explains it well:  https://blog.mariusschulz.com/2017/02/24/typescript-2-2-the-object-type

Anyone have any `object`ions to using `object`? :laughing: 

Codesandbox which uses these updated types so you can try it.  It's based on the React Typescript template, and compiler errors show up in the editor:  https://codesandbox.io/s/7z8v2nqv56
