### PR TITLE
Make view an argument to app as app({state,actions}, view).

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
-    "prettier": "^1.8.2",
-    "rollup": "^0.52.0",
-    "typescript": "^2.6.1",
-    "uglify-js": "^3.2.1"
+    "prettier": "^1.9.2",
+    "rollup": "^0.52.1",
+    "typescript": "^2.6.2",
+    "uglify-js": "^3.2.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,15 +27,15 @@ export function h(type, props) {
     : type(props || {}, children)
 }
 
-export function app(props, container) {
+export function app(model, view, container) {
   var lock
   var root = (container = container || document.body).children[0]
   var node = vnode(root, [].map)
   var lifecycle = []
-  var appState = props.state || {}
+  var appState = model.state || {}
   var appActions = {}
 
-  repaint(init(appState, appActions, props.actions, []))
+  repaint(init(appState, appActions, model.actions, []))
 
   return appActions
 
@@ -298,7 +298,7 @@ export function app(props, container) {
   function render(next) {
     lock = !lock
 
-    if (isFunction((next = props.view(appState)))) {
+    if (isFunction((next = view(appState)))) {
       next = next(appActions)
     }
 
@@ -310,7 +310,7 @@ export function app(props, container) {
   }
 
   function repaint() {
-    if (props.view && !lock) {
+    if (view && !lock) {
       setTimeout(render, (lock = !lock))
     }
   }

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -7,50 +7,56 @@ beforeEach(() => {
 })
 
 test("sync updates", done => {
-  app({
+  const model = {
     state: {
       value: 1
     },
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe(`<div>2</div>`)
-            done()
-          }
-        },
-        state.value
-      ),
     actions: {
       up: () => state => ({ value: state.value + 1 })
     }
-  }).up()
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>2</div>`)
+          done()
+        }
+      },
+      state.value
+    )
+
+  app(model, view).up()
 })
 
 test("async updates", done => {
-  app({
+  const model = {
     state: {
       value: 2
     },
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe(`<div>2</div>`)
-          },
-          onupdate() {
-            expect(document.body.innerHTML).toBe(`<div>3</div>`)
-            done()
-          }
-        },
-        state.value
-      ),
     actions: {
       up: data => state => ({ value: state.value + data }),
       upAsync: data => state => actions =>
         mockDelay().then(() => actions.up(data))
     }
-  }).upAsync(1)
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>2</div>`)
+        },
+        onupdate() {
+          expect(document.body.innerHTML).toBe(`<div>3</div>`)
+          done()
+        }
+      },
+      state.value
+    )
+
+  app(model, view).upAsync(1)
 })

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5,21 +5,10 @@ beforeEach(() => {
 })
 
 test("debouncing", done => {
-  app({
+  const model = {
     state: {
       value: 1
     },
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe("<div>5</div>")
-            done()
-          }
-        },
-        state.value
-      ),
     actions: {
       up: () => state => ({ value: state.value + 1 }),
       fire: () => state => actions => {
@@ -29,28 +18,45 @@ test("debouncing", done => {
         actions.up()
       }
     }
-  }).fire()
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div>5</div>")
+          done()
+        }
+      },
+      state.value
+    )
+
+  app(model, view).fire()
 })
 
 test("actions in the view", done => {
-  app({
+  const model = {
     state: {
       value: 0
-    },
-    view: state => actions => {
-      if (state.value < 1) {
-        return actions.up()
-      }
-
-      setTimeout(() => {
-        expect(document.body.innerHTML).toBe("<div>1</div>")
-        done()
-      })
-
-      return h("div", {}, state.value)
     },
     actions: {
       up: () => state => ({ value: state.value + 1 })
     }
-  })
+  }
+
+  const view = state => actions => {
+    if (state.value < 1) {
+      return actions.up()
+    }
+
+    setTimeout(() => {
+      expect(document.body.innerHTML).toBe("<div>1</div>")
+      done()
+    })
+
+    return h("div", {}, state.value)
+  }
+
+  app(model, view)
 })

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -6,46 +6,37 @@ beforeEach(() => {
 
 test("container", done => {
   document.body.innerHTML = "<main></main>"
-  app(
-    {
-      view: state =>
-        h(
-          "div",
-          {
-            oncreate() {
-              expect(document.body.innerHTML).toBe(
-                "<main><div>foo</div></main>"
-              )
-              done()
-            }
-          },
-          "foo"
-        )
-    },
-    document.body.firstChild
-  )
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<main><div>foo</div></main>")
+          done()
+        }
+      },
+      "foo"
+    )
+
+  app({}, view, document.body.firstChild)
 })
 
 test("nested container", done => {
   document.body.innerHTML = "<main><section></section><div></div></main>"
-  app(
-    {
-      view: state =>
-        h(
-          "p",
-          {
-            oncreate() {
-              expect(document.body.innerHTML).toBe(
-                `<main><section></section><div><p>foo</p></div></main>`
-              )
-              done()
-            }
-          },
-          "foo"
-        )
-    },
-    document.body.firstChild.lastChild
-  )
+  const view = state =>
+    h(
+      "p",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(
+            `<main><section></section><div><p>foo</p></div></main>`
+          )
+          done()
+        }
+      },
+      "foo"
+    )
+  app({}, view, document.body.firstChild.lastChild)
 })
 
 test("container with mutated host", done => {
@@ -54,40 +45,37 @@ test("container with mutated host", done => {
   const host = document.body.firstChild
   const container = host.firstChild
 
-  app(
-    {
-      state: {
-        value: "foo"
-      },
-      view: state => actions =>
-        h(
-          "p",
-          {
-            oncreate() {
-              expect(document.body.innerHTML).toBe(
-                `<main><div><p>foo</p></div></main>`
-              )
-              host.insertBefore(
-                document.createElement("header"),
-                host.firstChild
-              )
-              host.appendChild(document.createElement("footer"))
-
-              actions.bar()
-            },
-            onupdate() {
-              expect(document.body.innerHTML).toBe(
-                `<main><header></header><div><p>bar</p></div><footer></footer></main>`
-              )
-              done()
-            }
-          },
-          state.value
-        ),
-      actions: {
-        bar: () => ({ value: "bar" })
-      }
+  const model = {
+    state: {
+      value: "foo"
     },
-    container
-  )
+    actions: {
+      bar: () => ({ value: "bar" })
+    }
+  }
+
+  const view = state => actions =>
+    h(
+      "p",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(
+            `<main><div><p>foo</p></div></main>`
+          )
+          host.insertBefore(document.createElement("header"), host.firstChild)
+          host.appendChild(document.createElement("footer"))
+
+          actions.bar()
+        },
+        onupdate() {
+          expect(document.body.innerHTML).toBe(
+            `<main><header></header><div><p>bar</p></div><footer></footer></main>`
+          )
+          done()
+        }
+      },
+      state.value
+    )
+
+  app(model, view, container)
 })

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -2,19 +2,10 @@ import { h, app } from "../src"
 
 function testTreeSegue(name, trees) {
   test(name, done => {
-    app({
+    const model = {
       state: {
         index: 0
       },
-      view: state => actions =>
-        h(
-          "main",
-          {
-            oncreate: actions.next,
-            onupdate: actions.next
-          },
-          [trees[state.index].tree]
-        ),
       actions: {
         up: () => state => ({ index: state.index + 1 }),
         next: () => state => actions => {
@@ -29,7 +20,19 @@ function testTreeSegue(name, trees) {
           actions.up()
         }
       }
-    })
+    }
+
+    const view = state => actions =>
+      h(
+        "main",
+        {
+          oncreate: actions.next,
+          onupdate: actions.next
+        },
+        [trees[state.index].tree]
+      )
+
+    app(model, view)
   })
 }
 

--- a/test/hydration.test.js
+++ b/test/hydration.test.js
@@ -3,22 +3,18 @@ import { h, app } from "../src"
 function testHydration(name, ssrBody, children, container) {
   test(name, done => {
     document.body.innerHTML = ssrBody
-    app(
-      {
-        view: state =>
-          h(
-            "main",
-            {
-              onupdate() {
-                expect(document.body.innerHTML).toBe(ssrBody)
-                done()
-              }
-            },
-            children
-          )
-      },
-      container && document.getElementById(container)
-    )
+    const view = state =>
+      h(
+        "main",
+        {
+          onupdate() {
+            expect(document.body.innerHTML).toBe(ssrBody)
+            done()
+          }
+        },
+        children
+      )
+    app({}, view, container && document.getElementById(container))
   })
 }
 

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -5,131 +5,140 @@ beforeEach(() => {
 })
 
 test("oncreate", done => {
-  app({
-    view: () =>
-      h(
-        "div",
-        {
-          oncreate(element) {
-            element.className = "foo"
-            expect(document.body.innerHTML).toBe(`<div class="foo">foo</div>`)
-            done()
-          }
-        },
-        "foo"
-      )
-  })
+  const view = () =>
+    h(
+      "div",
+      {
+        oncreate(element) {
+          element.className = "foo"
+          expect(document.body.innerHTML).toBe(`<div class="foo">foo</div>`)
+          done()
+        }
+      },
+      "foo"
+    )
+
+  app({}, view)
 })
 
 test("onupdate", done => {
-  app({
+  const model = {
     state: { value: "foo" },
-
-    view: state => actions =>
-      h(
-        "div",
-        {
-          class: state.value,
-          oncreate() {
-            actions.repaint()
-          },
-          onupdate(element, oldProps) {
-            expect(element.textContent).toBe("foo")
-            expect(oldProps.class).toBe("foo")
-            done()
-          }
-        },
-        state.value
-      ),
     actions: {
       repaint: () => ({})
     }
-  })
+  }
+
+  const view = state => actions =>
+    h(
+      "div",
+      {
+        class: state.value,
+        oncreate() {
+          actions.repaint()
+        },
+        onupdate(element, oldProps) {
+          expect(element.textContent).toBe("foo")
+          expect(oldProps.class).toBe("foo")
+          done()
+        }
+      },
+      state.value
+    )
+
+  app(model, view)
 })
 
 test("onremove", done => {
-  app({
+  const model = {
     state: {
       value: true
     },
-    view: state => actions =>
-      state.value
-        ? h(
-            "ul",
-            {
-              oncreate() {
-                expect(document.body.innerHTML).toBe(
-                  "<ul><li></li><li></li></ul>"
-                )
-                actions.toggle()
-              }
-            },
-            [
-              h("li"),
-              h("li", {
-                onremove(element, remove) {
-                  remove()
-                  expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
-                  done()
-                }
-              })
-            ]
-          )
-        : h("ul", {}, [h("li")]),
     actions: {
       toggle: () => state => ({ value: !state.value })
     }
-  })
+  }
+
+  const view = state => actions =>
+    state.value
+      ? h(
+          "ul",
+          {
+            oncreate() {
+              expect(document.body.innerHTML).toBe(
+                "<ul><li></li><li></li></ul>"
+              )
+              actions.toggle()
+            }
+          },
+          [
+            h("li"),
+            h("li", {
+              onremove(element, remove) {
+                remove()
+                expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
+                done()
+              }
+            })
+          ]
+        )
+      : h("ul", {}, [h("li")])
+
+  app(model, view)
 })
 
 test("event bubling", done => {
   let count = 0
-  app({
+
+  const model = {
     state: {
       value: true
     },
-    view: state => actions =>
-      h(
-        "main",
-        {
-          oncreate() {
-            expect(count++).toBe(3)
-            actions.toggle()
-          },
-          onupdate() {
-            expect(count++).toBe(7)
-            done()
-          }
-        },
-        [
-          h("p", {
-            oncreate() {
-              expect(count++).toBe(2)
-            },
-            onupdate() {
-              expect(count++).toBe(6)
-            }
-          }),
-          h("p", {
-            oncreate() {
-              expect(count++).toBe(1)
-            },
-            onupdate() {
-              expect(count++).toBe(5)
-            }
-          }),
-          h("p", {
-            oncreate() {
-              expect(count++).toBe(0)
-            },
-            onupdate() {
-              expect(count++).toBe(4)
-            }
-          })
-        ]
-      ),
     actions: {
       toggle: () => state => ({ value: !state.value })
     }
-  })
+  }
+  
+  const view = state => actions =>
+    h(
+      "main",
+      {
+        oncreate() {
+          expect(count++).toBe(3)
+          actions.toggle()
+        },
+        onupdate() {
+          expect(count++).toBe(7)
+          done()
+        }
+      },
+      [
+        h("p", {
+          oncreate() {
+            expect(count++).toBe(2)
+          },
+          onupdate() {
+            expect(count++).toBe(6)
+          }
+        }),
+        h("p", {
+          oncreate() {
+            expect(count++).toBe(1)
+          },
+          onupdate() {
+            expect(count++).toBe(5)
+          }
+        }),
+        h("p", {
+          oncreate() {
+            expect(count++).toBe(0)
+          },
+          onupdate() {
+            expect(count++).toBe(4)
+          }
+        })
+      ]
+    )
+
+  app(model, view)
 })

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -5,18 +5,7 @@ beforeEach(() => {
 })
 
 test("state", done => {
-  const actions = app({
-    view: state =>
-      h(
-        "div",
-        {
-          oncreate() {
-            expect(document.body.innerHTML).toBe(`<div>fizzbuzz</div>`)
-            done()
-          }
-        },
-        state.fizz.buzz.value
-      ),
+  const model = {
     actions: {
       fizz: {
         buzz: {
@@ -24,12 +13,24 @@ test("state", done => {
         }
       }
     }
-  })
+  }
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>fizzbuzz</div>`)
+          done()
+        }
+      },
+      state.fizz.buzz.value
+    )
+  const actions = app(model, view)
 
   actions.fizz.buzz.fizzbuzz()
 })
 
-test("modules", done => {
+test("models", done => {
   const bar = {
     state: {
       value: true

--- a/test/svg.test.js
+++ b/test/svg.test.js
@@ -9,41 +9,40 @@ const deepExpectNS = (element, ns) =>
   })
 
 test("svg", done => {
-  app({
-    view: () =>
-      h(
-        "div",
-        {
-          oncreate() {
-            const foo = document.getElementById("foo")
-            const bar = document.getElementById("bar")
-            const baz = document.getElementById("baz")
+  const view = () =>
+    h(
+      "div",
+      {
+        oncreate() {
+          const foo = document.getElementById("foo")
+          const bar = document.getElementById("bar")
+          const baz = document.getElementById("baz")
 
-            expect(foo.namespaceURI).not.toBe(SVG_NS)
-            expect(baz.namespaceURI).not.toBe(SVG_NS)
-            expect(bar.namespaceURI).toBe(SVG_NS)
-            expect(bar.getAttribute("viewBox")).toBe("0 0 10 10")
-            deepExpectNS(bar, SVG_NS)
+          expect(foo.namespaceURI).not.toBe(SVG_NS)
+          expect(baz.namespaceURI).not.toBe(SVG_NS)
+          expect(bar.namespaceURI).toBe(SVG_NS)
+          expect(bar.getAttribute("viewBox")).toBe("0 0 10 10")
+          deepExpectNS(bar, SVG_NS)
 
-            done()
-          }
-        },
-        [
-          h("p", { id: "foo" }, "foo"),
-          h("svg", { id: "bar", viewBox: "0 0 10 10" }, [
-            h("quux", {}, [
-              h("beep", {}, [h("ping", {}), h("pong", {})]),
-              h("bop", {}),
-              h("boop", {}, [h("ping", {}), h("pong", {})])
-            ]),
-            h("xuuq", {}, [
-              h("beep", {}),
-              h("bop", {}, [h("ping", {}), h("pong", {})]),
-              h("boop", {})
-            ])
+          done()
+        }
+      },
+      [
+        h("p", { id: "foo" }, "foo"),
+        h("svg", { id: "bar", viewBox: "0 0 10 10" }, [
+          h("quux", {}, [
+            h("beep", {}, [h("ping", {}), h("pong", {})]),
+            h("bop", {}),
+            h("boop", {}, [h("ping", {}), h("pong", {})])
           ]),
-          h("p", { id: "baz" }, "baz")
-        ]
-      )
-  })
+          h("xuuq", {}, [
+            h("beep", {}),
+            h("bop", {}, [h("ping", {}), h("pong", {})]),
+            h("boop", {})
+          ])
+        ]),
+        h("p", { id: "baz" }, "baz")
+      ]
+    )
+  app({}, view)
 })


### PR DESCRIPTION
@whaaaley and I came up with an improvement to the current API without needing to merge state & actions, but making it easier to reduce boilerplate.

It consists of extracting the view from the props argument to app.

```jsx
app(props, view, container)
```

Props is the state and actions, same API as 0.16.2. While we are at it, I find it more logical to call it `model`, instead of props, so I'll do just that.

```jsx
const model = {
  state: {
    count: 0
  },
  actions: {
    down: () => state => ({ count: state.count - 1 }),
    up: () => state => ({ count: state.count + 1 })
  }
}

const view = state => actions => (
  <main>
    <h1>{state.count}</h1>
    <button onclick={actions.down}>-</button>
    <button onclick={actions.up}>+</button>
  </main>
)

app(model, view)
```

So almost nothing changes, but the advantage of this approach is that it makes it now easier to merge multiple models.

```jsx
app(
  combine({ A, B, C, D }),
  view,
  document.getElementById("root")
)
```

or

```jsx
app(
  {
    ...model,
    ...combine({ A, B, C, D })
  },
  view,
  document.getElementById("root")
)
```

Of course you need to write that custom `combine` function, but surely this can be pushed to userland.

---

## `combine(models)`
Creates a single model from multiple models. A model is an object of `{state,actions}` pairs. This function creates a single model from multiple models organized by their keys.


```jsx
const A = {
  state: { ... },
  actions: { ... }
}
const B = {
  state: { ... },
  actions: { ... }
}
const C = {
  state: { ... },
  actions: { ... }
}

combine({ A, B, C }) /*
{
  state: {
    A: A.state,
    B: B.state,
    B: B.state,
  },
  actions: {
    A: A.actions,
    B: B.actions,
    B: B.actions,
  },
}
*/
```

### Imperative

```jsx
const combine = models => {
  var out = {state:{},actions:{}}
  for (var key in models) {
    out.state[key] = models[key].state
    out.actions[key] = models[key].actions
  }
  return out
}
```

### Functional

```jsx
const combine = models =>
  Object.keys(models).reduce(
    (obj, key) => ({
      ...obj,
      ...{
        state: {
          ...obj.state,
          ...{ [key]: models[key].state }
        },
        actions: {
          ...obj.actions,
          ...{ [key]: models[key].actions }
        }
      }
    }),
    {}
  )
```