### PR TITLE
Add array capabilities to substate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,11 @@ export function app(state, actions, view, container) {
     for (var i in a) target[i] = a[i]
     for (var i in b) target[i] = b[i]
 
+    if (Array.isArray(a) || Array.isArray(b)) {
+      target.length = b && b.length || a && a.length
+      return Array.from(target)
+    }
+
     return target
   }
 

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -76,3 +76,64 @@ test("state/actions tree", done => {
 
   main.fizz.buzz.fizzbuzz()
 })
+
+
+test("array slices", done => {
+  const state = {
+    counts: [0, 0]
+  }
+
+  const actions = {
+    counts: {
+      up: (i) => state => ({ [i]: state[i] + 1 }),
+      add: (v) => state => ([...state, v])
+    }
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>0-1-0</div>`)
+          done()
+        }
+      },
+      state.counts.join("-")
+    )
+
+  const main = app(state, actions, view, document.body)
+
+  main.counts.add(0)
+  main.counts.up(1)
+})
+
+test("array slices/actions", done => {
+  const state = {
+    counts: [{
+      count: 0
+    }]
+  }
+
+  const actions = {
+    counts: [{
+      up: () => state => ({ count: state.count + 1 })
+    }]
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>1</div>`)
+          done()
+        }
+      },
+      state.counts[0].count
+    )
+
+  const main = app(state, actions, view, document.body)
+
+  main.counts[0].up()
+})


### PR DESCRIPTION
I am a litle bit late for 1.0 but lets do this ! 🚀 

As in JavaScript arrays are objects with key as integer and a length property (and Array methods 🙄 ),
a lot of you/us tried to use the substate (slices) capablity along with arrays. Then ran in some troubles.

The merge functions are aware about objects but not about arrays, so it always return the object form 
of the array.
But in JavaScript we have a method `Array.from` to retrieve and array from it object form.

This fix can be done both in userland or in core, but adding it in core add another feature.

Lets talk first about the userland solution.

The only main trouble is when iterating through the array to copy it, the length property is not itterated. So, the resulting target does not contain this property and we cant match the array properties (key as integer + length property).

In other words, by saving the length property, we will be able to use our slices arrays like we are doing it with regular object by applying the `Array.from` method in the view.

Please take a look at this pen : https://codepen.io/Swizz540/pen/JMWLXB?editors=0011

But, As I said earlier, adding it in core (for the cost of **34 bytes**) add another feature, the ability to use array of substate/actions :tada:

```jsx
const state = {
  counts: [{
    count: 0
  }]
}

const actions = {
  counts: [{
    up: () => state => ({ count: state.count + 1 })
  }]
}

const view = (state, actions) => (
  <div>
   {state.counts[0].count}
  </div>
)

const main = app(state, actions, view, document.body)

main.counts[0].up()
```

