### PR TITLE
Numeric Text Nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export function h(name, props) {
       }
     } else if (null == node || true === node || false === node) {
     } else {
-      children.push(typeof node === "number" ? node + "" : node)
+      children.push(node)
     }
   }
 
@@ -146,7 +146,7 @@ export function app(state, actions, view, container) {
   }
 
   function createElement(node, isSVG, element) {
-    if (typeof node === "string") {
+    if (typeof node === "string" || typeof node === "number") {
       element = document.createTextNode(node)
     } else {
       element = (isSVG = isSVG || "svg" === node.name)

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -32,7 +32,7 @@ test("positional String/Number children", () => {
   expect(h("div", {}, 0, "foo", 1, "baz", 2)).toEqual({
     name: "div",
     props: {},
-    children: ["0", "foo", "1", "baz", "2"]
+    children: [0, "foo", 1, "baz", 2]
   })
 
   expect(h("div", {}, "foo", h("div", {}, "bar"), "baz", "quux")).toEqual({


### PR DESCRIPTION
Handle text nodes as part of `patch` instead of converting to  a string in `h`.

Existing tests make sure this logic is covered.

-4 bytes