### PR TITLE
Refactor typings to allow for better intellisense and support in Typescript

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -63,7 +63,7 @@ export type NestedMap<T> = {
 /**
  * Type to describe anything that's not a function or object
  */
-export type Primitive = string | number | boolean | null | any[]
+export type Primitive = string | number | boolean | null | undefined | any[]
 
 /** The result of an action.
  *
@@ -83,46 +83,7 @@ export interface View<
   TState extends Primitive | NestedMap<Primitive>,
   TActions extends NestedMap<WiredAction<any, TState>>
 > {
-  (state: TState, actions: TActions): VNode<object>
-}
-
-/**
- * The action that's being passed to actions and returned from app()
- */
-type WiredAction<
-  TPayload extends Primitive | NestedMap<Primitive>,
-  TState extends Primitive | NestedMap<Primitive>
-> = (data?: TPayload) => TState
-
-/**
- * The action that's being passed to the actions object in app. 
- * Use this for implementing actions.
- */
-export type ActionType<
-  TState extends Primitive | NestedMap<Primitive> = any,
-  TActions extends
-    | NestedMap<WiredActions<TState, any>>
-    | NestedMap<UnwiredActions<TState, any>> = any,
-  TPayload extends Primitive | NestedMap<Primitive> = any
-> = (
-  data?: TPayload
-) =>
-  | ((state: TState, actions: TActions) => ActionResult<TState>)
-  | ActionResult<TState>
-
-/**
- * The interface for app(). Use this for implementing Higher Order App's
- */
-export interface App {
-  <
-    TState extends Primitive | NestedMap<Primitive>,
-    TActions extends UnwiredActions<TState, TActions>
-  >(
-    state: TState,
-    actions: TActions,
-    view: View<TState, TActions>,
-    container: HTMLElement | null
-  ): { [P in keyof TActions]: TActions[P] }
+  (state: TState, actions: TActions): VNode<any>
 }
 
 /** The app() call creates and renders a new application.
@@ -135,27 +96,71 @@ export interface App {
  */
 export declare const app: App
 
-/** 
- * Convenience type for State
+/**
+ * The interface for app(). Use this for implementing Higher Order App's
  */
-export interface StateType extends NestedMap<Primitive> {}
+export interface App {
+  <TState extends State, TActions extends UnwiredActions<TState, TActions>>(
+    state: TState,
+    actions: TActions,
+    view: View<TState, { [P in keyof TActions]: WiredAction<TState, any> }>,
+    container: HTMLElement | null
+  ): { [P in keyof TActions]: WiredAction<TState, any> }
+}
 
 /**
- * Convenience alias to extend your actions object from, when implementing actions.
+ * The action that's being passed to actions and returned from app()
  */
+type WiredAction<
+  TState extends Primitive | NestedMap<Primitive>,
+  TPayload extends Primitive | NestedMap<Primitive> = any
+> = (data?: TPayload) => TState
+
+/**
+ * The action that's being passed to app(). Use when you implement your actions.
+ */
+export type UnwiredAction<
+  TState extends State,
+  TActions extends UnwiredActions<TState, TActions>,
+  TPayload extends Primitive | NestedMap<Primitive> = any
+> = (
+  data?: TPayload
+) =>
+  | ((
+      state: TState,
+      actions: { [P in keyof TActions]: WiredAction<State, any> }
+    ) => ActionResult<TState>)
+  | ActionResult<TState>
+
+/** 
+ * Convenience type for defining initial State
+ */
+export interface State extends NestedMap<Primitive> {}
+
+/**
+ * Convenience alias from which you extend your actions object.
+ */
+// interface UnwiredActions<
+//   TState extends State,
+//   TActions extends { [P in keyof TActions]: WiredAction<TState> } = any
+// > extends NestedMap<TActions> {}
 interface UnwiredActions<
-  TState extends Primitive | NestedMap<Primitive> = any,
-  TActions extends NestedMap<
-    WiredActions<TState, TActions> | UnwiredActions<TState>
-  > = any
-> extends NestedMap<any> {}
+  TState extends State,
+  TActions extends UnwiredActions<
+    TState,
+    { [P in keyof TActions]: WiredAction<TState> }
+  >
+>
+  extends NestedMap<
+      UnwiredAction<TState, { [P in keyof TActions]: WiredAction<TState> }>
+    > {}
 
 /**
  * Convenience alias for NestedMap<WiredAction>
  */
 interface WiredActions<
-  TState extends Primitive | NestedMap<Primitive>,
-  TActions extends UnwiredActions
+  TState extends State,
+  TActions extends UnwiredActions<TState, TActions>
 > extends NestedMap<WiredAction<any, TState>> {}
 
 /** @namespace [JSX] */

--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -51,38 +51,78 @@ export function h<Props>(
 
 /** @namespace [App] */
 
+/**
+ * Type to describe a nested map of type T
+ * 
+ * example: { 'foo' : { 'bar': 1 }, 'baz': '' }
+ */
+export type NestedMap<T> = {
+  [key: string]: NestedMap<T> | T
+}
+
+/**
+ * Type to describe anything that's not a function or object
+ */
+export type Primitive = string | number | boolean | null | any[]
+
 /** The result of an action.
  *
  * @memberOf [App]
  */
-export type ActionResult<State> = Partial<State> | Promise<any> | null | void
-
-/** The interface for a single action implementation.
- *
- * @memberOf [App]
- */
-export type ActionType<State, Actions> = (
-  data?: any
-) =>
-  | ((state: State, actions: Actions) => ActionResult<State>)
-  | ActionResult<State>
-
-/** The interface for actions implementations.
- *
- * @memberOf [App]
- */
-export type ActionsType<State, Actions> = {
-  [P in keyof Actions]:
-    | ActionType<State, Actions>
-    | ActionsType<any, Actions[P]>
-}
+export type ActionResult<TState extends Primitive | NestedMap<Primitive>> =
+  | Partial<TState>
+  | Promise<any>
+  | null
+  | void
 
 /** The view function describes the application UI as a tree of VNodes.
  * @returns A VNode tree.
  * @memberOf [App]
  */
-export interface View<State, Actions> {
-  (state: State, actions: Actions): VNode<object>
+export interface View<
+  TState extends Primitive | NestedMap<Primitive>,
+  TActions extends NestedMap<WiredAction<any, TState>>
+> {
+  (state: TState, actions: TActions): VNode<object>
+}
+
+/**
+ * The action that's being passed to actions and returned from app()
+ */
+type WiredAction<
+  TPayload extends Primitive | NestedMap<Primitive>,
+  TState extends Primitive | NestedMap<Primitive>
+> = (data?: TPayload) => TState
+
+/**
+ * The action that's being passed to the actions object in app. 
+ * Use this for implementing actions.
+ */
+export type ActionType<
+  TState extends Primitive | NestedMap<Primitive> = any,
+  TActions extends
+    | NestedMap<WiredActions<TState, any>>
+    | NestedMap<UnwiredActions<TState, any>> = any,
+  TPayload extends Primitive | NestedMap<Primitive> = any
+> = (
+  data?: TPayload
+) =>
+  | ((state: TState, actions: TActions) => ActionResult<TState>)
+  | ActionResult<TState>
+
+/**
+ * The interface for app(). Use this for implementing Higher Order App's
+ */
+export interface App {
+  <
+    TState extends Primitive | NestedMap<Primitive>,
+    TActions extends UnwiredActions<TState, TActions>
+  >(
+    state: TState,
+    actions: TActions,
+    view: View<TState, TActions>,
+    container: HTMLElement | null
+  ): { [P in keyof TActions]: TActions[P] }
 }
 
 /** The app() call creates and renders a new application.
@@ -92,17 +132,33 @@ export interface View<State, Actions> {
  * @param view The view function.
  * @param container The DOM element where the app will be rendered to.
  * @returns The actions wired to the application.
- * @memberOf [App]
  */
-export function app<State, Actions>(
-  state: State,
-  actions: ActionsType<State, Actions>,
-  view: View<State, Actions>,
-  container: Element | null
-): Actions
+export declare const app: App
+
+/** 
+ * Convenience type for State
+ */
+export interface StateType extends NestedMap<Primitive> {}
+
+/**
+ * Convenience alias to extend your actions object from, when implementing actions.
+ */
+interface UnwiredActions<
+  TState extends Primitive | NestedMap<Primitive> = any,
+  TActions extends NestedMap<
+    WiredActions<TState, TActions> | UnwiredActions<TState>
+  > = any
+> extends NestedMap<any> {}
+
+/**
+ * Convenience alias for NestedMap<WiredAction>
+ */
+interface WiredActions<
+  TState extends Primitive | NestedMap<Primitive>,
+  TActions extends UnwiredActions
+> extends NestedMap<WiredAction<any, TState>> {}
 
 /** @namespace [JSX] */
-
 declare global {
   namespace JSX {
     interface Element<Data> extends VNode<object> {}

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -1,24 +1,41 @@
-import { h, app, ActionsType, View } from "hyperapp"
+import {
+  h,
+  app,
+  View,
+  State as StateType,
+  UnwiredActions,
+  NestedMap,
+  UnwiredAction,
+  WiredActions,
+} from 'hyperapp'
 
 namespace Counter {
-  export interface State {
+  export interface State extends StateType {
     count: number
+    clickCount: number
   }
 
-  export interface Actions {
-    down(): State
-    up(value: number): State
+  export interface Actions extends UnwiredActions<State, Actions> {
+    down: UnwiredAction<State, Actions>
+    up: UnwiredAction<State, Actions, number>
+    addClickCount: UnwiredAction<State, Actions>
   }
 
   export const state: State = {
-    count: 0
+    count: 0,
+    clickCount: 0,
   }
 
-  export const actions: ActionsType<State, Actions> = {
-    down: () => state => ({ count: state.count - 1 }),
-    up: (value: number) => state => ({
-      count: state.count + value
-    })
+  export const actions: Actions = {
+    down: () => (state, actions) => {
+      actions.addClickCount()
+      return { count: state.count - 1 }
+    },
+    up: (value = 1) => (state, actions) => {
+      actions.addClickCount()
+      return { count: state.count + value }
+    },
+    addClickCount: () => state => ({ clickCount: state.clickCount + 1 }),
   }
 }
 
@@ -26,13 +43,16 @@ const view: View<Counter.State, Counter.Actions> = (state, actions) => (
   <main>
     <div>{state.count}</div>
     <button onclick={actions.down}>-</button>
-    <button onclick={actions.up}>+</button>
+    <button onclick={() => actions.up()}>+</button>
+    <button onclick={() => actions.up(5)}>+5</button>
   </main>
 )
 
-app<Counter.State, Counter.Actions>(
+const appActions = app<Counter.State, Counter.Actions>(
   Counter.state,
   Counter.actions,
   view,
   document.body
 )
+
+appActions.up();

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -1,4 +1,4 @@
-import { h, app, View, StateType, UnwiredActions, UnwiredAction } from 'hyperapp'
+import { h, app, View, StateType, UnwiredActions, UnwiredAction } from "hyperapp"
 
 namespace Counter {
   export interface State extends StateType {

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -39,11 +39,11 @@ const view: View<Counter.State, Counter.Actions> = (state, actions) => (
   </main>
 )
 
-const appActions = app<Counter.State, Counter.Actions>(
+const main = app<Counter.State, Counter.Actions>(
   Counter.state,
   Counter.actions,
   view,
   document.body
 )
 
-appActions.up()
+main.up()

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -1,13 +1,4 @@
-import {
-  h,
-  app,
-  View,
-  State as StateType,
-  UnwiredActions,
-  NestedMap,
-  UnwiredAction,
-  WiredActions,
-} from 'hyperapp'
+import { h, app, View, StateType, UnwiredActions, UnwiredAction } from 'hyperapp'
 
 namespace Counter {
   export interface State extends StateType {
@@ -55,4 +46,4 @@ const appActions = app<Counter.State, Counter.Actions>(
   document.body
 )
 
-appActions.up();
+appActions.up()


### PR DESCRIPTION
As a continuation of this PR (https://github.com/hyperapp/hyperapp/pull/535 that might be gone...) I've created this PR.

**!! Please have a look at this, anyone who has interest in Typings !!**

I've changed the typings considerably and I need to polish them. In the mean time it would be nice to review them for what there is now. 

A list of the changes:

- all generics are prefixed with T to make the difference between types/interfaces and generics clear
- I've added a generic NestedMap<T> as helper type to form the other types (specifically State and Actions, and their derivatives)
- I changed the exported 'app()' signature. Right now it's an implementation of an interface that's being exported (this allows @lassecapel to type the app that's passed into his HOA)
- I've added WiredAction and UnwiredAction and their object wrappers as aliases so it's more convenient for implementing objects for respectively State/SubState and Actions/SubActions
- I changed the signature of the generics so that the TPayload is always last and optional

Things to do:

- [x] fix the build (test/index.tsx in particular)
- [x] fix formatting according to Hyperapp standards
- [x] allow for nested types and actions to be in the same way accessible as the return value of `App` interface
- [x] change and move documentation in the proper place
- [ ] allow for nested actions to get the nested state based on the path where the action is mounted
- [ ] _In progress_: implement recommendations from review (please take a critical look at the current types and the uses of `any` as defaults for generics)
- [ ] [discussion] there are now the concepts of `UnwiredAction`, `WiredAction`. I'm wondering if we should keep it this way. I feel that it gives good distinction between the two, but others think otherwise. 
- [x] Not applicable anymore ~~[discussion] a lot of generics are now typed optional with `any`, it might be better to have them non-optional~~

  
  