### PR TITLE
Add unpkg entry for bare URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/hyperapp.js",
   "jsnext:main": "src/index.js",
   "module": "src/index.js",
+  "unpkg": "dist/hyperapp.js",
   "typings": "hyperapp.d.ts",
   "license": "MIT",
   "repository": "hyperapp/hyperapp",


### PR DESCRIPTION
This allows people to use src/index.js using a "bare" unpkg URL like
https://unpkg.com/hyperapp instead of requiring people to use the
?module flag, which is a little overkill for hyperapp since everything
is in a single file anyway.

It does, however, require that src/index.js always be runnable in a
browser environment, which may be something that you don't want. In that
case, it'd be better to point unpkg at dist/hyperapp.js to make sure people
get your built files instead. Up to you!