### PR TITLE
Better async actions support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,12 +104,17 @@ export function app(state, actions, view, container) {
 
               if (
                 data &&
-                data !== (state = get(path, globalState)) &&
-                !data.then // Promise
+                data !== (state = get(path, globalState))
               ) {
-                scheduleRender(
-                  (globalState = set(path, copy(state, data), globalState))
-                )
+								if (data.then) {
+									data.then(data => scheduleRender(
+										(globalState = set(path, copy(state, data), globalState))
+									))
+								} else {
+								  scheduleRender(
+									(globalState = set(path, copy(state, data), globalState))
+								  )
+								}
               }
 
               return data

--- a/src/index.js
+++ b/src/index.js
@@ -102,19 +102,18 @@ export function app(state, actions, view, container) {
                 data = data(get(path, globalState), actions)
               }
 
-              if (
-                data &&
-                data !== (state = get(path, globalState))
-              ) {
-								if (data.then) {
-									data.then(data => scheduleRender(
-										(globalState = set(path, copy(state, data), globalState))
-									))
-								} else {
-								  scheduleRender(
-									(globalState = set(path, copy(state, data), globalState))
-								  )
-								}
+              if (data && data !== (state = get(path, globalState))) {
+                if (data.then) {
+                  data.then(function(data) {
+                    return scheduleRender(
+                      (globalState = set(path, copy(state, data), globalState))
+                    )
+                  })
+                } else {
+                  scheduleRender(
+                    (globalState = set(path, copy(state, data), globalState))
+                  )
+                }
               }
 
               return data

--- a/src/index.js
+++ b/src/index.js
@@ -102,14 +102,20 @@ export function app(state, actions, view, container) {
                 data = data(get(path, globalState), actions)
               }
 
-              if (data && data !== (state = get(path, globalState))) {
+              if (data) {
                 if (data.then) {
                   data.then(function(data) {
-                    return scheduleRender(
-                      (globalState = set(path, copy(state, data), globalState))
-                    )
+                    if (data !== (state = get(path, globalState))) {
+                      return scheduleRender(
+                        (globalState = set(
+                          path,
+                          copy(state, data),
+                          globalState
+                        ))
+                      )
+                    }
                   })
-                } else {
+                } else if (data !== (state = get(path, globalState))) {
                   scheduleRender(
                     (globalState = set(path, copy(state, data), globalState))
                   )


### PR DESCRIPTION
This allows you to return objects from async functions/promises to be merged into state the same way as you would in a sync function

This would allow you to write
```js
export default {
	state: {
		result: null,
		error: null,
	},
	actions: {
		login: () => async () => {
			try {
				return {
					result: await authProm,
					error: null,
				}
			} catch (error) {
				return {
					error
				}
			}
		}
	},
};
```

instead of 
```js
export default {
	state: {
		result: null,
		error: null,
	},
	actions: {
		login: () => async (state, actions) => {
			try {
				actions.setResult(await authProm);
				actions.setError(null);
			} catch (error) {
				actions.setError(error);
			}
		},
		setError: error => ({ error }),
		setResult: result => ({ result }),
	},
};
```