### PR TITLE
app() should not remove root element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,11 @@ export function app(state, actions, view, container) {
 
   return wiredActions
 
+  function insert (element, newNode, referenceNode) {
+    if (newNode === referenceNode) element.prepend(newNode)
+    else element.insertBefore(newNode, referenceNode)
+  }
+
   function toVNode(element, map) {
     return {
       name: element.nodeName.toLowerCase(),
@@ -308,7 +313,9 @@ export function app(state, actions, view, container) {
         createElement(node, isSVG),
         (nextSibling = element)
       )
-      removeElement(parent, nextSibling, oldNode)
+      if (nextSibling !== rootElement) {
+        removeElement(parent, nextSibling, oldNode)
+      }
     }
     return element
   }

--- a/src/index.js
+++ b/src/index.js
@@ -37,11 +37,6 @@ export function app(state, actions, view, container) {
 
   return wiredActions
 
-  function insert (element, newNode, referenceNode) {
-    if (newNode === referenceNode) element.prepend(newNode)
-    else element.insertBefore(newNode, referenceNode)
-  }
-
   function toVNode(element, map) {
     return {
       name: element.nodeName.toLowerCase(),

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -738,3 +738,21 @@ testTreeSegue("elements with falsey values", [
     html: `<div></div>`
   }
 ])
+
+test('does not remove other tags', done => {
+  const actions = {
+    next: () => () => {
+      expect(document.body.innerHTML).toBe(
+        `<div></div><script></script>`
+      )
+      return done()
+    }
+  }
+
+  const view = (state, actions) => h("div", {
+    oncreate: actions.next
+  })
+
+  document.body.innerHTML = `<script></script>`
+  const main = app({}, actions, view, document.body)
+})


### PR DESCRIPTION
Right now, if you have a body like this: `<body><script><script></body>` and use the demo code in the [Readme intro](https://github.com/hyperapp/hyperapp/blob/master/README.md), the script tag will be replaced with the `<main>` element. This is probably not desirable.

This PR fixes that and adds a test. However, please take a close look at the PR since I am not 100% sure if it is a strong fix — I don't have enough familiarity with the codebase to know what sort of situations this might break in. In what cases is this last `else` actually triggered, other than initially on the first patch?

Cheers.