### PR TITLE
Documentation link fix

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,5 +1,5 @@
 # Tutorials
 
-* [TweetBox](tutorials/tweetbox.md)
-* [Gif Search](tutorials/gif-search.md)
-* [Countdown Timer](tutorials/countdown-timer.md)
+* [TweetBox](tweetbox.md)
+* [Gif Search](gif-search.md)
+* [Countdown Timer](countdown-timer.md)


### PR DESCRIPTION
The tutorials links in the tutorials README.md have 1 too many 'tutorials' in the path, fixed these 3 links by removing the extra word.