### PR TITLE
Add vNode structure mapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,11 +18,15 @@ export function h(name, props) {
 
   return typeof name === "function"
     ? name(props || {}, children)
-    : {
+    : h.vNodeMap({
         name: name,
         props: props || {},
         children: children
-      }
+      })
+}
+
+h.vNodeMap = function(node) {
+  return node
 }
 
 export function app(state, actions, view, container) {
@@ -38,7 +42,7 @@ export function app(state, actions, view, container) {
   return wiredActions
 
   function toVNode(element, map) {
-    return {
+    return h.vNodeMap({
       name: element.nodeName.toLowerCase(),
       props: {},
       children: map.call(element.childNodes, function(element) {
@@ -46,7 +50,7 @@ export function app(state, actions, view, container) {
           ? element.nodeValue
           : toVNode(element, map)
       })
-    }
+    })
   }
 
   function render() {

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -111,3 +111,25 @@ test("component with no props adds default props", () => {
     children: ["Hello world"]
   })
 })
+
+test("vnode with extended properties", () => {
+  const mapper = h.vNodeMap
+
+  h.vNodeMap = ({ name, props, children }) => ({
+    name,
+    props,
+    children,
+    nodeName: name,
+    attributes: props
+  })
+
+  expect(h("div", {}, ["foo"])).toEqual({
+    name: "div",
+    props: {},
+    children: ["foo"],
+    nodeName: "div",
+    attributes: {}
+  })
+
+  h.vNodeMap = mapper
+})


### PR DESCRIPTION
#### Allows vNode compatibility with external frameworks and libraries

Now you can, define any vNode structure without affecting hyperapp

```javascript

// before any `h` call
h.vNodeMap => ({ name, props, children }) => ({
    name,
    props,
    children,
    nodeName: name,
    attributes: props
})
```
as result virtual nodes will get the new node structure

* please notice, `name`, `props` and `children` shouldn't be overwritten

### PR Changes:
- adds vNode mapper as `h` constructor property
- adds tests