### PR TITLE
Mount app by replacing a given element instead of rendering into a container.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ yarn.lock
 package-lock.json
 
 # Misc
-examples
+example*
 notes/
 node_modules
 coverage


### PR DESCRIPTION
Without removing automatic rehydration, this PR changes Hyperapp's mount strategy. Currently, it renders the app into a given container. If the container **is not** empty, Hyperapp tries to reuse the existing markup (rehydration).

The new behavior, proposed by this PR, is to replace the given DOM element and attempt to rehydrate anyway. 

This PR also adds a `recycled` prop to the VNode to tell the updateElement that the old node was recycled. With this information, we are able to call `oncreate`, instead of `onupdate` on the first render. 

---

I would prefer to keep the default behavior instead of adding all this complexity, but if this is what everyone wants, then I am down for it.