### PR TITLE
Enable re-hydration via recycleElement passed to app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ const actions = {
 
 #### Nested Actions
 
+> **Work In Progress**: This section is not perfect and may be incomplete. Please help.
+
 Actions can be nested inside namespaces. Updating deeply nested state is as easy as declaring actions inside an object in the same path as the part of the state you want to update.
 
 ```jsx
@@ -195,6 +197,43 @@ const view = (state, actions) =>
 ```
 
 It is important to understand that the result of the view is a new Virtual DOM. It may seem wasteful to throw away the old Virtual DOM and re-create it entirely on every update — not to mention the fact that at any one time, Hyperapp is keeping two Virtual DOM trees in memory, but as it turns out, browsers can create hundreds of thousands of objects very quickly. On the other hand, modifying the DOM is several orders of magnitude more expensive.
+
+## Mounting
+
+> **Work In Progress**: This section is not perfect and may be incomplete. Please help.
+
+Hyperapp will mount your rendered view into the given <samp>container</samp> Element. The default behavior is non-destructive. We will not take over any existing elements inside the container.
+
+```js
+app(state, actions, view, container)
+```
+
+### SSR
+
+Hyperapp works transparently with SSR and pre-rendered HTML, enabling SEO optimization and improving your sites time-to-interactive. The process consists of serving a fully pre-rendered page together with your application and providing a <samp>recycleElement</samp> DOM element to the <samp>app</samp> function.
+
+```js
+app(state, actions, view, container, recycleElement)
+```
+
+```html
+<html>
+<head>
+  <meta charset="utf-8">
+  <script defer src="bundle.js"></script>
+</head>
+
+<body>
+  <div>
+    <h1>0</h1>
+    <button>-</button>
+    <button>+</button>
+  </div>
+</body>
+</html>
+```
+
+Then instead of throwing away the pre-rendered markdown, we'll turn your DOM element into an interactive application out of the box.
 
 ## Virtual DOM
 
@@ -468,29 +507,6 @@ const PlayerList = ({ players }) =>
       </li>
     ))
 ```
-
-## Hydration
-
-Hyperapp works transparently with SSR and pre-rendered HTML, enabling SEO optimization and improving your sites time-to-interactive. The process consists of serving a fully pre-rendered page together with your application.
-
-```html
-<html>
-<head>
-  <meta charset="utf-8">
-  <script defer src="bundle.js"></script>
-</head>
-
-<body>
-  <div>
-    <h1>0</h1>
-    <button>-</button>
-    <button>+</button>
-  </div>
-</body>
-</html>
-```
-
-Then instead of throwing away the server-rendered markdown, we'll turn your DOM nodes into an interactive application out of the box.
 
 ## Community
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,10 @@ export function h(name, attributes /*, ...rest*/) {
       }
 }
 
-export function app(state, actions, view, container) {
+export function app(state, actions, view, container, element) {
   var renderLock
   var invokeLaterStack = []
-  var rootElement = (container && container.children[0]) || null
-  var oldNode = rootElement && toVNode(rootElement, [].map)
+  var oldNode = element && toVNode(element, [].map)
   var globalState = clone(state)
   var wiredActions = clone(actions)
 
@@ -55,7 +54,7 @@ export function app(state, actions, view, container) {
 
     var next = view(globalState, wiredActions)
     if (container && !renderLock) {
-      rootElement = patch(container, rootElement, oldNode, (oldNode = next))
+      element = patch(container, element, oldNode, (oldNode = next))
     }
 
     while ((next = invokeLaterStack.pop())) next()


### PR DESCRIPTION
This new behavior is more back-portable than #589 , but still breaking, since we will not rehydrate unless a <samp>recycleElement</samp> is provided to the app function.

Now the app function accepts an additional optional argument: <samp>recycleElement</samp> that will be used to update a specific element. This means you can have multiple apps rendered into `document.body`, without interference.

The new default behavior is to append to the provided <samp>container</samp> element, without rehydration. We will not attempt to recycle any existing markup unless you also pass a <samp>recycleElement</samp> to the app function.

I still need to fix tests and we need to debate how we want lifecycle events to be invoked during rehydration (that is do we want to keep the current behavior in Hyperapp ~1.0.0 or do we want to call <samp>oncreate</samp> even if the element **already** exists). 

I added a new section "mounting" as suggested by @zaceno, but I am not happy at all with the documentation of this part. If you could help, I would appreciate it.

