### PR TITLE
Make boolean "false" a valid attribute value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,11 +137,11 @@ export function app(state, actions, view, container) {
     } else {
       if (typeof value === "function" || (name in element && !isSVG)) {
         element[name] = value == null ? "" : value
-      } else if (value != null && value !== false) {
+      } else if (value != null) {
         element.setAttribute(name, value)
       }
 
-      if (value == null || value === false) {
+      if (value == null) {
         element.removeAttribute(name)
       }
     }

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -749,7 +749,7 @@ testTreeSegue("elements with falsey values", [
     tree: h("div", {
       "data-test": false
     }),
-    html: `<div></div>`
+    html: `<div data-test="false"></div>`
   },
   {
     tree: h("div", {


### PR DESCRIPTION
before: `<div data-attr={false} />` => `<div></div>`
after: `<div data-attr={false} />` => `<div data-attr="false"></div>`

Useful for attributes such as [draggable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable) and for custom data-attributes.

The does not affect props like `checked` and they will continue work as previously.
Hope this change also decrease library size on a few bytes :)