### PR TITLE
Invoke oncreate instead of onupdate on hydration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export function h(name, attributes /*, ...rest*/) {
 }
 
 export function app(state, actions, view, container) {
+  var init = true
   var renderLock
   var invokeLaterStack = []
   var rootElement = (container && container.children[0]) || null
@@ -56,6 +57,7 @@ export function app(state, actions, view, container) {
     var next = view(globalState, wiredActions)
     if (container && !renderLock) {
       rootElement = patch(container, rootElement, oldNode, (oldNode = next))
+      init = false
     }
 
     while ((next = invokeLaterStack.pop())) next()
@@ -195,9 +197,10 @@ export function app(state, actions, view, container) {
       }
     }
 
-    if (attributes.onupdate) {
+    var event = init ? attributes.oncreate : attributes.onupdate
+    if (event) {
       invokeLaterStack.push(function() {
-        attributes.onupdate(element, oldAttributes)
+        event(element, oldAttributes)
       })
     }
   }

--- a/test/hydration.test.js
+++ b/test/hydration.test.js
@@ -9,7 +9,7 @@ test("hydration", done => {
     h(
       "main",
       {
-        onupdate() {
+        oncreate() {
           expect(document.body.innerHTML).toBe(SSR_BODY)
           done()
         }


### PR DESCRIPTION
Allows to init third-party libs if `app` was started on non empty container.

Fixes #588 
Refs #589