### PR TITLE
Add a test to make sure JSX fragment support won't be broken in the future

### DIFF
--- a/test/h.test.js
+++ b/test/h.test.js
@@ -111,3 +111,14 @@ test("component with no props adds default props", () => {
     children: ["Hello world"]
   })
 })
+
+test("fragments", () => {
+  const Fragment = (_, children) => children
+
+  expect(h(Fragment, {}, ["A", "B", h(Fragment, {}, ["C", "D"])])).toEqual([
+    "A",
+    "B",
+    "C",
+    "D"
+  ])
+})


### PR DESCRIPTION
Looks like Hyperapp already support JSX Fragments, need to just add docs how to use them:

```js
import { h, app } from 'hyperapp'
const Fragment = (_, children) => children

const view = () => (
  <main>
    <Fragment>
      <h1>A</h1>
      <h1>B</h1>
    </Fragment>
  </main>
)

app({}, {}, view, document.body)

console.log(document.body.innerHTML)
// => <main><h1>A</h1><h1>B</h1></main>
```

Demo: https://codepen.io/frenzzy/pen/WMZMVb?editors=0010

To use `<></>` syntax, use the following .babelrc config:
```js
{
  "plugins": [
    ["@babel/plugin-transform-react-jsx", { "pragma": "h", "pragmaFrag": "Fragment" }]
  ]
}
```
and your view may look like this:
```js
const view = () => (
  <main>
    <>
      <h1>A</h1>
      <h1>B</h1>
    </>
  </main>
)
```

After #591 we will be able to use fragments as a root node:
```js
const view = () => (
  <>
    <h1>A</h1>
    <h1>B</h1>
  </>
)
```

refs:
- [babel-plugin-transform-react-jsx#pragmaFrag](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx#pragmafrag)
- [Fragments in React.js](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html)

Closes #530