### PR TITLE
Add connected components

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,20 @@ const HelloBox = ({ name }) => (
 )
 ```
 
+### Connected Components
+
+Normal components are dumb (not wired to your application state or actions), since they only receive their props and children from the parent component.  To create a connected component simply change the component signature.
+
+```jsx
+const DumbComponent = (props, children) => (
+  <div>Hello</div>
+);
+
+const ConnectedComponent = (props, children) => (state, actions) => (
+  <div>Hello, {state.name}!</div>
+);
+```
+
 ## Lifecycle Events
 
 You can be notified when elements managed by the Virtual DOM are created, updated or removed via lifecycle events. Use them for animation, data fetching, wrapping third party libraries, cleaning up resources, etc.

--- a/src/index.js
+++ b/src/index.js
@@ -150,8 +150,8 @@ export function app(state, actions, view, container) {
   }
 
   function connect(children, i) {
-    typeof children[i] === "function" &&
-      (children[i] = children[i](globalState, wiredActions))
+    if (typeof children[i] === "function")
+      children[i] = children[i](globalState, wiredActions)
   }
 
   function createElement(node, isSVG) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export function app(state, actions, view, container) {
     }
   }
 
-  function inflate(children) {
+  function connect(children) {
     for (var i in children) {
       if (typeof children[i] === "function")
         children[i] = children[i](globalState, wiredActions)
@@ -175,7 +175,7 @@ export function app(state, actions, view, container) {
         })
       }
 
-      var c = inflate(node.children)
+      var c = connect(node.children)
       for (var i in c) {
         element.appendChild(createElement(c[i], isSVG))
       }
@@ -270,7 +270,7 @@ export function app(state, actions, view, container) {
       var i = 0
       var j = 0
 
-      var c = inflate(node.children)
+      var c = connect(node.children)
       while (j < c.length) {
         var oldChild = oldNode.children[i]
         var newChild = node.children[j]

--- a/src/index.js
+++ b/src/index.js
@@ -51,14 +51,6 @@ export function app(state, actions, view, container) {
     }
   }
 
-  function connect(children) {
-    for (var i in children) {
-      if (typeof children[i] === "function")
-        children[i] = children[i](globalState, wiredActions)
-    }
-    return children
-  }
-
   function render() {
     renderLock = !renderLock
 
@@ -157,6 +149,11 @@ export function app(state, actions, view, container) {
     }
   }
 
+  function connect(children, i) {
+    typeof children[i] === "function" &&
+      (children[i] = children[i](globalState, wiredActions))
+  }
+
   function createElement(node, isSVG) {
     var element =
       typeof node === "string" || typeof node === "number"
@@ -175,8 +172,9 @@ export function app(state, actions, view, container) {
         })
       }
 
-      var c = connect(node.children)
+      var c = node.children
       for (var i in c) {
+        connect(c, i)
         element.appendChild(createElement(c[i], isSVG))
       }
 
@@ -270,8 +268,9 @@ export function app(state, actions, view, container) {
       var i = 0
       var j = 0
 
-      var c = connect(node.children)
+      var c = node.children
       while (j < c.length) {
+        connect(c, i)
         var oldChild = oldNode.children[i]
         var newChild = node.children[j]
 

--- a/src/index.js
+++ b/src/index.js
@@ -172,10 +172,9 @@ export function app(state, actions, view, container) {
         })
       }
 
-      var c = node.children
-      for (var i in c) {
-        connect(c, i)
-        element.appendChild(createElement(c[i], isSVG))
+      for (var i = 0; i < node.children.length; i++) {
+        connect(node.children, i)
+        element.appendChild(createElement(node.children[i], isSVG))
       }
 
       for (var name in node.attributes) {
@@ -267,9 +266,8 @@ export function app(state, actions, view, container) {
       var i = 0
       var j = 0
 
-      var c = node.children
-      while (j < c.length) {
-        connect(c, i)
+      while (j < node.children.length) {
+        connect(node.children, i)
         var oldChild = oldNode.children[i]
         var newChild = node.children[j]
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,10 @@ export function app(state, actions, view, container) {
 
   function inflate(children) {
     for (var i in children) {
-      typeof children[i] === "function" && (children[i] = children[i](globalState, wiredActions));
+      typeof children[i] === "function" &&
+        (children[i] = children[i](globalState, wiredActions))
     }
-    return children;
+    return children
   }
 
   function render() {
@@ -174,7 +175,7 @@ export function app(state, actions, view, container) {
         })
       }
 
-      var c = inflate(node.children);
+      var c = inflate(node.children)
       for (var i = 0; i < c.length; i++) {
         element.appendChild(createElement(c[i], isSVG))
       }
@@ -268,7 +269,7 @@ export function app(state, actions, view, container) {
       var i = 0
       var j = 0
 
-      var c = inflate(node.children);
+      var c = inflate(node.children)
       while (j < c.length) {
         var oldChild = oldNode.children[i]
         var newChild = node.children[j]

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export function app(state, actions, view, container) {
   }
 
   function get(path, source) {
-    for (var i in path) {
+    for (var i = 0; i < path.length; i++) {
       source = source[path[i]]
     }
     return source
@@ -214,9 +214,8 @@ export function app(state, actions, view, container) {
 
   function removeChildren(element, node, attributes) {
     if ((attributes = node.attributes)) {
-      var c = node.children
-      for (var i in c) {
-        removeChildren(element.childNodes[i], c[i])
+      for (var i = 0; i < node.children.length; i++) {
+        removeChildren(element.childNodes[i], node.children[i])
       }
 
       if (attributes.ondestroy) {
@@ -254,7 +253,7 @@ export function app(state, actions, view, container) {
       var oldKeyed = {}
       var newKeyed = {}
 
-      for (var i in oldNode.children) {
+      for (var i = 0; i < oldNode.children.length; i++) {
         oldElements[i] = element.childNodes[i]
 
         var oldChild = oldNode.children[i]
@@ -320,8 +319,9 @@ export function app(state, actions, view, container) {
       }
 
       for (var i in oldKeyed) {
-        if (!newKeyed[oldKeyed[i][1].key])
+        if (!newKeyed[oldKeyed[i][1].key]) {
           removeElement(element, oldKeyed[i][0], oldKeyed[i][1])
+        }
       }
     } else if (node.nodeName === oldNode.nodeName) {
       element.nodeValue = node

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export function app(state, actions, view, container) {
   }
 
   function inflate(children) {
-    for (let i in children) {
+    for (var i in children) {
       typeof children[i] === "function" && (children[i] = children[i](globalState, wiredActions));
     }
     return children;

--- a/src/index.js
+++ b/src/index.js
@@ -53,8 +53,8 @@ export function app(state, actions, view, container) {
 
   function inflate(children) {
     for (var i in children) {
-      typeof children[i] === "function" &&
-        (children[i] = children[i](globalState, wiredActions))
+      if (typeof children[i] === "function")
+        children[i] = children[i](globalState, wiredActions)
     }
     return children
   }
@@ -98,7 +98,7 @@ export function app(state, actions, view, container) {
   }
 
   function get(path, source) {
-    for (var i = 0; i < path.length; i++) {
+    for (var i in path) {
       source = source[path[i]]
     }
     return source
@@ -176,7 +176,7 @@ export function app(state, actions, view, container) {
       }
 
       var c = inflate(node.children)
-      for (var i = 0; i < c.length; i++) {
+      for (var i in c) {
         element.appendChild(createElement(c[i], isSVG))
       }
 
@@ -216,8 +216,9 @@ export function app(state, actions, view, container) {
 
   function removeChildren(element, node, attributes) {
     if ((attributes = node.attributes)) {
-      for (var i = 0; i < node.children.length; i++) {
-        removeChildren(element.childNodes[i], node.children[i])
+      var c = node.children
+      for (var i in c) {
+        removeChildren(element.childNodes[i], c[i])
       }
 
       if (attributes.ondestroy) {
@@ -255,7 +256,7 @@ export function app(state, actions, view, container) {
       var oldKeyed = {}
       var newKeyed = {}
 
-      for (var i = 0; i < oldNode.children.length; i++) {
+      for (var i in oldNode.children) {
         oldElements[i] = element.childNodes[i]
 
         var oldChild = oldNode.children[i]
@@ -320,9 +321,8 @@ export function app(state, actions, view, container) {
       }
 
       for (var i in oldKeyed) {
-        if (!newKeyed[oldKeyed[i][1].key]) {
+        if (!newKeyed[oldKeyed[i][1].key])
           removeElement(element, oldKeyed[i][0], oldKeyed[i][1])
-        }
       }
     } else if (node.nodeName === oldNode.nodeName) {
       element.nodeValue = node

--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,21 @@ export function app(state, actions, view, container) {
     }
   }
 
+  function inflate(node) {
+    if (node) {
+      var c = node.children || []
+      for (var i in c) {
+        typeof c[i] === "function" &&
+          (c[i] = inflate(c[i](globalState, wiredActions)))
+      }
+    }
+    return node
+  }
+
   function render() {
     renderLock = !renderLock
 
-    var next = view(globalState, wiredActions)
+    var next = inflate(view(globalState, wiredActions))
     if (container && !renderLock) {
       rootElement = patch(container, rootElement, oldNode, (oldNode = next))
       firstRender = false

--- a/src/index.js
+++ b/src/index.js
@@ -51,21 +51,17 @@ export function app(state, actions, view, container) {
     }
   }
 
-  function inflate(node) {
-    if (node) {
-      var c = node.children || []
-      for (var i in c) {
-        typeof c[i] === "function" &&
-          (c[i] = inflate(c[i](globalState, wiredActions)))
-      }
+  function inflate(children) {
+    for (let i in children) {
+      typeof children[i] === "function" && (children[i] = children[i](globalState, wiredActions));
     }
-    return node
+    return children;
   }
 
   function render() {
     renderLock = !renderLock
 
-    var next = inflate(view(globalState, wiredActions))
+    var next = view(globalState, wiredActions)
     if (container && !renderLock) {
       rootElement = patch(container, rootElement, oldNode, (oldNode = next))
       firstRender = false
@@ -178,8 +174,9 @@ export function app(state, actions, view, container) {
         })
       }
 
-      for (var i = 0; i < node.children.length; i++) {
-        element.appendChild(createElement(node.children[i], isSVG))
+      var c = inflate(node.children);
+      for (var i = 0; i < c.length; i++) {
+        element.appendChild(createElement(c[i], isSVG))
       }
 
       for (var name in node.attributes) {
@@ -271,7 +268,8 @@ export function app(state, actions, view, container) {
       var i = 0
       var j = 0
 
-      while (j < node.children.length) {
+      var c = inflate(node.children);
+      while (j < c.length) {
         var oldChild = oldNode.children[i]
         var newChild = node.children[j]
 

--- a/test/inflation.test.js
+++ b/test/inflation.test.js
@@ -1,0 +1,33 @@
+import { h, app } from "../src"
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+test("inflation of connected components", done => {
+  const state = {
+    value: 1
+  }
+
+  const actions = {}
+
+  const view = state =>
+    h("a", {}, (state, actions) =>
+      h("b", {}, [
+        state.value,
+        (state, actions) =>
+          h(
+            "c",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe("<a><b>1<c>1</c></b></a>")
+                done()
+              }
+            },
+            state.value
+          )
+      ])
+    )
+
+  app(state, actions, view, document.body)
+})


### PR DESCRIPTION
## Connected Components
### Why?
Currently all components are dumb components.  Given a component hierarchy A->B->C->D->E.  If Component `E` needed access to `state.name` then components A, B, C, and D would each need to be updated to pass along state.name.  This causes components to become tightly coupled, or written generically so that all state and actions are handed down to every child component, because of the "you never know when you'll need it" mentality.

### The Solution
Natively support both dumb components and connected components. 

Normal dumb component signature:
```jsx
const Component = (props, children) => (
  <div>Hello</div>
);
```

Connected component signature:
```jsx
const ConnectedComponent = (props, children) => (state, actions) => (
  <div>Hello, {state.name}</div>
);
```

This solution does not require use of either a Higher Order App or a Higher Order Component. 

### How does it work?
In hyperapp's `render` function, whenever the view is processed, the resulting object tree is traversed.  Any child node that is a function is called with the `globalState` and `wiredActions`.

This change raised the gzip size by ~30 bytes.