### PR TITLE
Support array in state or partial state root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,17 @@ export function app(state, actions, view, container) {
   }
 
   function clone(target, source) {
+    if (Array.isArray(target)) {
+      if (!source) {
+        return target.concat();
+      }
+
+      return target.map(function(a, i) {
+        return source[i] || a;
+      })
+      .concat(source.slice(target.length));
+    }
+
     var obj = {}
 
     for (var i in target) obj[i] = target[i]

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -51,6 +51,56 @@ test("slices", done => {
   done()
 })
 
+test("slices and array", done => {
+  const bar = {
+    state: [],
+    actions: {
+      add: () => state => state.concat('b')
+    }
+  }
+
+  const foo = {
+    state: {
+      value: [],
+      bar: bar.state
+    },
+    actions: {
+      add: () => state => ({value: state.value.concat('a')}),
+      bar: bar.actions
+    }
+  }
+
+  const state = {
+    foo: foo.state
+  }
+
+  const actions = {
+    foo: foo.actions,
+    getState: () => state => state
+  }
+
+  const main = app(state, actions, () => {})
+
+  expect(main.getState()).toEqual({
+    foo: {
+      value: [],
+      bar: []
+    }
+  })
+
+  expect(main.foo.add()).toEqual({value: ['a']})
+  expect(main.foo.bar.add()).toEqual(['b'])
+
+  expect(main.getState()).toEqual({
+    foo: {
+      value: ['a'],
+      bar: ['b']
+    }
+  })
+
+  done()
+})
+
 test("state/actions tree", done => {
   const actions = {
     fizz: {


### PR DESCRIPTION
Currently state root or action divided root supports only objects, due to the clone method. With small changes following could be possible.

```js
var state = [];
var actions = {
    add: n => state => state.concat(n),
    getState: () => state => state
};
var main = app(state, actions, () => {})

main.add(1); // => [1]
main.getState(); // => [1]
```