### PR TITLE
Support for non-object slices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,10 @@ export function app(state, actions, view, container) {
     return source
   }
 
+  function isObject(val) {
+    return Object.prototype.toString.call(val) === "[object Object]"
+  }
+
   function wireStateToActions(path, state, actions) {
     for (var key in actions) {
       typeof actions[key] === "function"
@@ -106,12 +110,16 @@ export function app(state, actions, view, container) {
               }
 
               if (
-                data &&
+                data != null &&
                 data !== (state = get(path, globalState)) &&
                 !data.then // Promise
               ) {
                 scheduleRender(
-                  (globalState = set(path, clone(state, data), globalState))
+                  (globalState = set(
+                    path,
+                    isObject(data) ? clone(state, data) : data,
+                    globalState
+                  ))
                 )
               }
 
@@ -120,7 +128,9 @@ export function app(state, actions, view, container) {
           })(key, actions[key])
         : wireStateToActions(
             path.concat(key),
-            (state[key] = clone(state[key])),
+            state[key] == null || isObject(state[key])
+              ? (state[key] = clone(state[key]))
+              : state[key],
             (actions[key] = clone(actions[key]))
           )
     }

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -83,3 +83,29 @@ test("state/actions tree", done => {
   main.foo.bar.baz.foobarbaz()
   expect(state).toEqual({ foo: {} })
 })
+
+test("non-object slices", () => {
+  const state = {
+    number: 1,
+    string: "foo",
+    array: ["a"]
+  }
+
+  const actions = {
+    number: { add: value => state => state + value },
+    string: { add: value => state => state + value },
+    array: { add: value => state => state.concat(value) },
+    getState: () => state => state
+  }
+
+  const main = app(state, actions, () => {})
+
+  expect(main.number.add(-1)).toBe(0)
+  expect(main.string.add("bar")).toBe("foobar")
+  expect(main.array.add("b")).toEqual(["a", "b"])
+  expect(main.getState()).toEqual({
+    number: 0,
+    string: "foobar",
+    array: ["a", "b"]
+  })
+})


### PR DESCRIPTION
An alternative solution for #609 and #512

- It allows to write more simple code as described in this comment: https://github.com/hyperapp/hyperapp/pull/609#issuecomment-367253627
- It allows to change data type of a slice or easily override/remove it
- It makes custom merge method unnecessary #532 (I hope)
