### PR TITLE
New function to allow `app` creation with inversion of control

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,21 +33,25 @@ function clone(target, source) {
   return obj
 }
 
-export var app = hyper(
-  // (node , parent, globalState, wiredActions) => node
-  function getVNode(node) {
-    if (node == null || typeof node === "boolean") {
-      return ""
-    }
-    if (typeof node.nodeName === "function") {
-      return getVNode(node.nodeName(node.attributes, node.children))
-    }
-    return node
+function getVNode(node) {
+  if (node == null || typeof node === "boolean") {
+    return ""
   }
-)
+  if (typeof node.nodeName === "function") {
+    return getVNode(node.nodeName(node.attributes, node.children))
+  }
+  return node
+}
 
-export function hyper(parseNode) {
-  return function app(state, actions, view, container) {
+export function app(state, actions, view, container) {
+  var parseNode = getVNode
+  if (typeof state === "function") {
+    parseNode = state
+    return createApp
+  }
+  return createApp(state, actions, view, container)
+
+  function createApp(state, actions, view, container) {
     var renderLock
     var firstRender = true
     var lifecycleStack = []

--- a/src/index.js
+++ b/src/index.js
@@ -24,31 +24,17 @@ export function h(name, attributes /*, ...rest*/) {
   }
 }
 
-export function app(state, actions, view, container) {
-  var renderLock
-  var firstRender = true
-  var lifecycleStack = []
-  var rootElement = (container && container.children[0]) || null
-  var oldNode = rootElement && toVNode(rootElement, [].map)
-  var globalState = clone(state)
-  var wiredActions = clone(actions)
+function clone(target, source) {
+  var obj = {}
 
-  scheduleRender(wireStateToActions([], globalState, wiredActions))
+  for (var i in target) obj[i] = target[i]
+  for (var i in source) obj[i] = source[i]
 
-  return wiredActions
+  return obj
+}
 
-  function toVNode(element, map) {
-    return {
-      nodeName: element.nodeName.toLowerCase(),
-      attributes: {},
-      children: map.call(element.childNodes, function(element) {
-        return element.nodeType === 3 // Node.TEXT_NODE
-          ? element.nodeValue
-          : toVNode(element, map)
-      })
-    }
-  }
-
+export var app = hyper(
+  // (node , parent, globalState, wiredActions) => node
   function getVNode(node) {
     if (node == null || typeof node === "boolean") {
       return ""
@@ -58,286 +44,318 @@ export function app(state, actions, view, container) {
     }
     return node
   }
+)
 
-  function render() {
-    renderLock = !renderLock
+export function hyper(parseNode) {
+  return function app(state, actions, view, container) {
+    var renderLock
+    var firstRender = true
+    var lifecycleStack = []
+    var rootElement = (container && container.children[0]) || null
+    var oldNode = rootElement && toVNode(rootElement, [].map)
+    var globalState = clone(state)
+    var wiredActions = clone(actions)
 
-    var next = view(globalState, wiredActions)
-    if (container && !renderLock) {
-      rootElement = patch(
-        container,
-        rootElement,
-        oldNode,
-        (oldNode = getVNode(next))
-      )
-      firstRender = false
-    }
+    scheduleRender(wireStateToActions([], globalState, wiredActions))
 
-    while ((next = lifecycleStack.pop())) next()
-  }
+    return wiredActions
 
-  function scheduleRender() {
-    if (!renderLock) {
-      renderLock = !renderLock
-      setTimeout(render)
-    }
-  }
-
-  function clone(target, source) {
-    var obj = {}
-
-    for (var i in target) obj[i] = target[i]
-    for (var i in source) obj[i] = source[i]
-
-    return obj
-  }
-
-  function set(path, value, source) {
-    var target = {}
-    if (path.length) {
-      target[path[0]] =
-        path.length > 1 ? set(path.slice(1), value, source[path[0]]) : value
-      return clone(source, target)
-    }
-    return value
-  }
-
-  function get(path, source) {
-    for (var i = 0; i < path.length; i++) {
-      source = source[path[i]]
-    }
-    return source
-  }
-
-  function wireStateToActions(path, state, actions) {
-    for (var key in actions) {
-      typeof actions[key] === "function"
-        ? (function(key, action) {
-            actions[key] = function(data) {
-              if (typeof (data = action(data)) === "function") {
-                data = data(get(path, globalState), actions)
-              }
-
-              if (
-                data &&
-                data !== (state = get(path, globalState)) &&
-                !data.then // Promise
-              ) {
-                scheduleRender(
-                  (globalState = set(path, clone(state, data), globalState))
-                )
-              }
-
-              return data
-            }
-          })(key, actions[key])
-        : wireStateToActions(
-            path.concat(key),
-            (state[key] = state[key] || {}),
-            (actions[key] = clone(actions[key]))
-          )
-    }
-  }
-
-  function getKey(node) {
-    return node ? node.key : null
-  }
-
-  function updateAttribute(element, name, value, isSVG, oldValue) {
-    if (name === "key") {
-    } else if (name === "style") {
-      for (var i in clone(oldValue, value)) {
-        element[name][i] = value == null || value[i] == null ? "" : value[i]
-      }
-    } else {
-      if (typeof value === "function" || (name in element && !isSVG)) {
-        element[name] = value == null ? "" : value
-      } else if (value != null && value !== false) {
-        element.setAttribute(name, value)
-      }
-
-      if (value == null || value === false) {
-        element.removeAttribute(name)
-      }
-    }
-  }
-
-  function createElement(node, isSVG) {
-    var element =
-      typeof node === "string" || typeof node === "number"
-        ? document.createTextNode(node)
-        : (isSVG = isSVG || node.nodeName === "svg")
-          ? document.createElementNS(
-              "http://www.w3.org/2000/svg",
-              node.nodeName
-            )
-          : document.createElement(node.nodeName)
-
-    if (node.attributes) {
-      if (node.attributes.oncreate) {
-        lifecycleStack.push(function() {
-          node.attributes.oncreate(element)
+    function toVNode(element, map) {
+      return {
+        nodeName: element.nodeName.toLowerCase(),
+        attributes: {},
+        children: map.call(element.childNodes, function(element) {
+          return element.nodeType === 3 // Node.TEXT_NODE
+            ? element.nodeValue
+            : toVNode(element, map)
         })
       }
+    }
 
-      for (var i = 0; i < node.children.length; i++) {
-        element.appendChild(
-          createElement((node.children[i] = getVNode(node.children[i])), isSVG)
+    function render() {
+      renderLock = !renderLock
+
+      var next = view(globalState, wiredActions)
+      if (container && !renderLock) {
+        rootElement = patch(
+          container,
+          rootElement,
+          oldNode,
+          (oldNode = parseNode(next, {}, globalState, wiredActions))
         )
+        firstRender = false
       }
 
-      for (var name in node.attributes) {
-        updateAttribute(element, name, node.attributes[name], isSVG)
-      }
+      while ((next = lifecycleStack.pop())) next()
     }
 
-    return element
-  }
-
-  function updateElement(element, oldAttributes, attributes, isSVG) {
-    for (var name in clone(oldAttributes, attributes)) {
-      if (
-        attributes[name] !==
-        (name === "value" || name === "checked"
-          ? element[name]
-          : oldAttributes[name])
-      ) {
-        updateAttribute(
-          element,
-          name,
-          attributes[name],
-          isSVG,
-          oldAttributes[name]
-        )
+    function scheduleRender() {
+      if (!renderLock) {
+        renderLock = !renderLock
+        setTimeout(render)
       }
     }
 
-    var cb = firstRender ? attributes.oncreate : attributes.onupdate
-    if (cb) {
-      lifecycleStack.push(function() {
-        cb(element, oldAttributes)
-      })
-    }
-  }
-
-  function removeChildren(element, node, attributes) {
-    if ((attributes = node.attributes)) {
-      for (var i = 0; i < node.children.length; i++) {
-        removeChildren(element.childNodes[i], node.children[i])
+    function set(path, value, source) {
+      var target = {}
+      if (path.length) {
+        target[path[0]] =
+          path.length > 1 ? set(path.slice(1), value, source[path[0]]) : value
+        return clone(source, target)
       }
+      return value
+    }
 
-      if (attributes.ondestroy) {
-        attributes.ondestroy(element)
+    function get(path, source) {
+      for (var i = 0; i < path.length; i++) {
+        source = source[path[i]]
+      }
+      return source
+    }
+
+    function wireStateToActions(path, state, actions) {
+      for (var key in actions) {
+        typeof actions[key] === "function"
+          ? (function(key, action) {
+              actions[key] = function(data) {
+                if (typeof (data = action(data)) === "function") {
+                  data = data(get(path, globalState), actions)
+                }
+
+                if (
+                  data &&
+                  data !== (state = get(path, globalState)) &&
+                  !data.then // Promise
+                ) {
+                  scheduleRender(
+                    (globalState = set(path, clone(state, data), globalState))
+                  )
+                }
+
+                return data
+              }
+            })(key, actions[key])
+          : wireStateToActions(
+              path.concat(key),
+              (state[key] = state[key] || {}),
+              (actions[key] = clone(actions[key]))
+            )
       }
     }
-    return element
-  }
 
-  function removeElement(parent, element, node, cb) {
-    function done() {
-      parent.removeChild(removeChildren(element, node))
+    function getKey(node) {
+      return node ? node.key : null
     }
 
-    if (node.attributes && (cb = node.attributes.onremove)) {
-      cb(element, done)
-    } else {
-      done()
-    }
-  }
-
-  function patch(parent, element, oldNode, node, isSVG, nextSibling) {
-    if (node === oldNode) {
-    } else if (oldNode == null) {
-      element = parent.insertBefore(createElement(node, isSVG), element)
-    } else if (node.nodeName && node.nodeName === oldNode.nodeName) {
-      updateElement(
-        element,
-        oldNode.attributes,
-        node.attributes,
-        (isSVG = isSVG || node.nodeName === "svg")
-      )
-
-      var oldElements = []
-      var oldKeyed = {}
-      var newKeyed = {}
-
-      for (var i = 0; i < oldNode.children.length; i++) {
-        oldElements[i] = element.childNodes[i]
-
-        var oldChild = oldNode.children[i]
-        var oldKey = getKey(oldChild)
-
-        if (null != oldKey) {
-          oldKeyed[oldKey] = [oldElements[i], oldChild]
+    function updateAttribute(element, name, value, isSVG, oldValue) {
+      if (name === "key") {
+      } else if (name === "style") {
+        for (var i in clone(oldValue, value)) {
+          element[name][i] = value == null || value[i] == null ? "" : value[i]
         }
-      }
-
-      var i = 0
-      var j = 0
-
-      while (j < node.children.length) {
-        var oldChild = oldNode.children[i]
-        var newChild = (node.children[j] = getVNode(node.children[j]))
-
-        var oldKey = getKey(oldChild)
-        var newKey = getKey(newChild)
-
-        if (newKeyed[oldKey]) {
-          i++
-          continue
+      } else {
+        if (typeof value === "function" || (name in element && !isSVG)) {
+          element[name] = value == null ? "" : value
+        } else if (value != null && value !== false) {
+          element.setAttribute(name, value)
         }
 
-        if (newKey == null) {
-          if (oldKey == null) {
-            patch(element, oldElements[i], oldChild, newChild, isSVG)
-            j++
-          }
-          i++
-        } else {
-          var recyledNode = oldKeyed[newKey] || []
+        if (value == null || value === false) {
+          element.removeAttribute(name)
+        }
+      }
+    }
 
-          if (oldKey === newKey) {
-            patch(element, recyledNode[0], recyledNode[1], newChild, isSVG)
-            i++
-          } else if (recyledNode[0]) {
-            patch(
-              element,
-              element.insertBefore(recyledNode[0], oldElements[i]),
-              recyledNode[1],
-              newChild,
+    function createElement(node, isSVG) {
+      var element =
+        typeof node === "string" || typeof node === "number"
+          ? document.createTextNode(node)
+          : (isSVG = isSVG || node.nodeName === "svg")
+            ? document.createElementNS(
+                "http://www.w3.org/2000/svg",
+                node.nodeName
+              )
+            : document.createElement(node.nodeName)
+
+      if (node.attributes) {
+        if (node.attributes.oncreate) {
+          lifecycleStack.push(function() {
+            node.attributes.oncreate(element)
+          })
+        }
+
+        for (var i = 0; i < node.children.length; i++) {
+          element.appendChild(
+            createElement(
+              (node.children[i] = parseNode(
+                node.children[i],
+                node,
+                globalState,
+                wiredActions
+              )),
               isSVG
             )
-          } else {
-            patch(element, oldElements[i], null, newChild, isSVG)
+          )
+        }
+
+        for (var name in node.attributes) {
+          updateAttribute(element, name, node.attributes[name], isSVG)
+        }
+      }
+
+      return element
+    }
+
+    function updateElement(element, oldAttributes, attributes, isSVG) {
+      for (var name in clone(oldAttributes, attributes)) {
+        if (
+          attributes[name] !==
+          (name === "value" || name === "checked"
+            ? element[name]
+            : oldAttributes[name])
+        ) {
+          updateAttribute(
+            element,
+            name,
+            attributes[name],
+            isSVG,
+            oldAttributes[name]
+          )
+        }
+      }
+
+      var cb = firstRender ? attributes.oncreate : attributes.onupdate
+      if (cb) {
+        lifecycleStack.push(function() {
+          cb(element, oldAttributes)
+        })
+      }
+    }
+
+    function removeChildren(element, node, attributes) {
+      if ((attributes = node.attributes)) {
+        for (var i = 0; i < node.children.length; i++) {
+          removeChildren(element.childNodes[i], node.children[i])
+        }
+
+        if (attributes.ondestroy) {
+          attributes.ondestroy(element)
+        }
+      }
+      return element
+    }
+
+    function removeElement(parent, element, node, cb) {
+      function done() {
+        parent.removeChild(removeChildren(element, node))
+      }
+
+      if (node.attributes && (cb = node.attributes.onremove)) {
+        cb(element, done)
+      } else {
+        done()
+      }
+    }
+
+    function patch(parent, element, oldNode, node, isSVG, nextSibling) {
+      if (node === oldNode) {
+      } else if (oldNode == null) {
+        element = parent.insertBefore(createElement(node, isSVG), element)
+      } else if (node.nodeName && node.nodeName === oldNode.nodeName) {
+        updateElement(
+          element,
+          oldNode.attributes,
+          node.attributes,
+          (isSVG = isSVG || node.nodeName === "svg")
+        )
+
+        var oldElements = []
+        var oldKeyed = {}
+        var newKeyed = {}
+
+        for (var i = 0; i < oldNode.children.length; i++) {
+          oldElements[i] = element.childNodes[i]
+
+          var oldChild = oldNode.children[i]
+          var oldKey = getKey(oldChild)
+
+          if (null != oldKey) {
+            oldKeyed[oldKey] = [oldElements[i], oldChild]
+          }
+        }
+
+        var i = 0
+        var j = 0
+
+        while (j < node.children.length) {
+          var oldChild = oldNode.children[i]
+          var newChild = (node.children[j] = parseNode(
+            node.children[j],
+            node,
+            globalState,
+            wiredActions
+          ))
+
+          var oldKey = getKey(oldChild)
+          var newKey = getKey(newChild)
+
+          if (newKeyed[oldKey]) {
+            i++
+            continue
           }
 
-          j++
-          newKeyed[newKey] = newChild
-        }
-      }
+          if (newKey == null) {
+            if (oldKey == null) {
+              patch(element, oldElements[i], oldChild, newChild, isSVG)
+              j++
+            }
+            i++
+          } else {
+            var recyledNode = oldKeyed[newKey] || []
 
-      while (i < oldNode.children.length) {
-        var oldChild = oldNode.children[i]
-        if (getKey(oldChild) == null) {
-          removeElement(element, oldElements[i], oldChild)
-        }
-        i++
-      }
+            if (oldKey === newKey) {
+              patch(element, recyledNode[0], recyledNode[1], newChild, isSVG)
+              i++
+            } else if (recyledNode[0]) {
+              patch(
+                element,
+                element.insertBefore(recyledNode[0], oldElements[i]),
+                recyledNode[1],
+                newChild,
+                isSVG
+              )
+            } else {
+              patch(element, oldElements[i], null, newChild, isSVG)
+            }
 
-      for (var i in oldKeyed) {
-        if (!newKeyed[oldKeyed[i][1].key]) {
-          removeElement(element, oldKeyed[i][0], oldKeyed[i][1])
+            j++
+            newKeyed[newKey] = newChild
+          }
         }
+
+        while (i < oldNode.children.length) {
+          var oldChild = oldNode.children[i]
+          if (getKey(oldChild) == null) {
+            removeElement(element, oldElements[i], oldChild)
+          }
+          i++
+        }
+
+        for (var i in oldKeyed) {
+          if (!newKeyed[oldKeyed[i][1].key]) {
+            removeElement(element, oldKeyed[i][0], oldKeyed[i][1])
+          }
+        }
+      } else if (node.nodeName === oldNode.nodeName) {
+        element.nodeValue = node
+      } else {
+        element = parent.insertBefore(
+          createElement(node, isSVG),
+          (nextSibling = element)
+        )
+        removeElement(parent, nextSibling, oldNode)
       }
-    } else if (node.nodeName === oldNode.nodeName) {
-      element.nodeValue = node
-    } else {
-      element = parent.insertBefore(
-        createElement(node, isSVG),
-        (nextSibling = element)
-      )
-      removeElement(parent, nextSibling, oldNode)
+      return element
     }
-    return element
   }
 }

--- a/test/components.test.js
+++ b/test/components.test.js
@@ -1,0 +1,80 @@
+import { h, app } from "../src"
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+test("components", done => {
+  const Component = (props, children) => h("div", props, children)
+
+  const view = () =>
+    h(
+      Component,
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div>foo<div>bar</div></div>")
+          done()
+        }
+      },
+      ["foo", h(Component, {}, "bar")]
+    )
+
+  app({}, {}, view, document.body)
+})
+
+test("nested components", done => {
+  const Child = (props, children) => h("div", props, children)
+  const Parent = (props, children) => h(Child, props, children)
+
+  const view = () =>
+    h(
+      Parent,
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div>foo</div>")
+          done()
+        }
+      },
+      ["foo"]
+    )
+
+  app({}, {}, view, document.body)
+})
+
+test("component with no props adds default props", done => {
+  const Component = ({ name = "world" }, children) =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div>Hello world</div>")
+          done()
+        }
+      },
+      "Hello " + name
+    )
+
+  const view = () => h(Component)
+
+  app({}, {}, view, document.body)
+})
+
+test("component with null and Boolean children", done => {
+  const ComponentNull = () => null
+  const ComponentTrue = () => true
+  const ComponentFalse = () => false
+
+  const view = () =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div>foo</div>")
+          done()
+        }
+      },
+      ["foo", h(ComponentNull), h(ComponentTrue), h(ComponentFalse)]
+    )
+
+  app({}, {}, view, document.body)
+})

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -67,47 +67,12 @@ test("vnode with attributes", () => {
   })
 })
 
-test("skip null and Boolean children", () => {
-  const expected = {
-    nodeName: "div",
-    attributes: {},
-    children: []
-  }
-
-  expect(h("div", {}, true)).toEqual(expected)
-  expect(h("div", {}, false)).toEqual(expected)
-  expect(h("div", {}, null)).toEqual(expected)
-})
-
-test("components", () => {
-  const Component = (props, children) => h("div", props, children)
+test("component", () => {
+  const Component = () => h("div", {}, ["baz"])
 
   expect(h(Component, { id: "foo" }, "bar")).toEqual({
-    nodeName: "div",
+    nodeName: Component,
     attributes: { id: "foo" },
     children: ["bar"]
-  })
-
-  expect(h(Component, { id: "foo" }, [h(Component, { id: "bar" })])).toEqual({
-    nodeName: "div",
-    attributes: { id: "foo" },
-    children: [
-      {
-        nodeName: "div",
-        attributes: { id: "bar" },
-        children: []
-      }
-    ]
-  })
-})
-
-test("component with no props adds default props", () => {
-  const Component = ({ name = "world" }, children) =>
-    h("div", {}, "Hello " + name)
-
-  expect(h(Component)).toEqual({
-    nodeName: "div",
-    attributes: {},
-    children: ["Hello world"]
   })
 })


### PR DESCRIPTION
# Inversion of Control

## Why?
The base `app` function that Hyperapp supplies is perfect for covering the common use case.  It can be customized pretty easily with Higher-Order Apps and Higher-Order Components.  Unfortunately HOA/HOC can only take you so far.  Some features need to be implemented inside `app` itself.  Features like connected components or context would be beneficial to some, but those not using the features would have to pay the performance price.  The PR is to enable app creation with inversion of control -- empowering users to add the features themselves.

## Details
```jsx
import { h, app } from 'hyperapp';
```
With this PR these would continue to work exactly as they do today; however, a new `hyper` function would also be available.
```jsx
import { h, hyper } from 'hyperapp';
```
The `hyper` function takes a `parseNode` function and returns an `app` function.
The `parseNode` function has the following signature:
```jsx
const parseNode = (node, parent, globalState, wiredActions) => /* node */
```

✳️ **EDIT:** _The `hyper` function has been replaced with an overloaded `app` function.  Example:_
```js
app(parseNode)(state, actions, view, document.body);
```
✳️ **EDIT:** _To be clear, the `parseNode` functions are not supplied by HyperApp, but instead developed by the community.  Below are a few examples I created just to show some of the capabilities._

### Example: App supporting Context
```jsx
const { h, hyper } from 'hyperapp';
// Create the app with a custom node parser
const app = hyper(nodeParserWithContext);
// Thanks to nodeParserWithContext every component now receives context!
const Component = (props, children, context) => <div />;
app(state, actions, view, document.body);
```
Want to see it in action?  Check out this [CodePen](https://codepen.io/jason-whitted/pen/BYVjmb).

### Example: Using Context to create Provider/connect (like redux)
Building upon the previous Context example, we can easily create a `Provider` component and `connect` HOC.

Want to see it in action?  Check out this [CodePen](https://codepen.io/jason-whitted/pen/LQrGam).

### Example: App supporting Connected Components
```jsx
const { h, hyper } from 'hyperapp';
// Create the app with a custom current parser
const app = hyper(nodeParserWithCurrent);
// Thanks to nodeParserWithCurrent every component now receives a current object
// The current object has getState() and getActions() methods
const Component = (props, children, { getState, getActions }) => <div />;
app(state, actions, view, document.body);
```
Want to see it in action?  Check out this [CodePen](https://codepen.io/jason-whitted/pen/OQENPL).

### Example: App that combines children into props
```jsx
const { h, hyper } from 'hyperapp';
// Create the app with a custom parser
const app = hyper(nodeParserWithChildrenInProps);
// Thanks to nodeParserWithChildrenInProps every component now only receives one props object
const Component = ({ children, ...other }) => <div>{children}</div>;
app(state, actions, view, document.body);
```

Want to see it in action?  Check out this [CodePen](https://codepen.io/jason-whitted/pen/GQGZqV).

### Example: Error Boundaries
```jsx
const { h, hyper } from 'hyperapp';
// Create the app with a custom error boundary node parser
const app = hyper(nodeParserWithErrorBoundary);
// Thanks to nodeParserWithErrorBoundary components that throw errors can be handled
const Throw = (props, children) => { throw new Error('Boom!'); }
app(state, actions, view, document.body);
```

Want to see it in action?  Check out this [CodePen](https://codepen.io/jason-whitted/pen/GQGZyg)

## Conclusion
This PR should have no negative performance impact; however, it should be able to satisfy many of the following issues / PRs: #388, #615, #601, #569, #604, etc.
