### PR TITLE
Actions with multiple arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export function app(state, actions, view, container) {
       typeof actions[key] === "function"
         ? (function(key, action) {
             actions[key] = function(data) {
-              if (typeof (data = action(data)) === "function") {
+              if (typeof (data = action.apply(null, arguments)) === "function") {
                 data = data(get(path, globalState), actions)
               }
 

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -100,3 +100,31 @@ test("call action within action", done => {
 
   main.upAndFoo()
 })
+
+test("action with multiple arguments", done => {
+  const state = {
+    value: 0
+  }
+
+  const actions = {
+    up: (a, b, c) => state => ({
+      value: state.value + a + b + c
+    })
+  }
+
+  const view = state =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe(`<div>6</div>`)
+          done()
+        }
+      },
+      state.value
+    )
+
+  const main = app(state, actions, view, document.body)
+
+  main.up(1, 2, 3)
+})


### PR DESCRIPTION
Looks like a bug:
```js
const actions = {
  up: (a, b, c) => state => {
    console.log(a) // => 1
    console.log(b) // => undefined (expected: 2)
    console.log(c) // => undefined (expected: 3)
  }
}

const main = app({}, actions, () => {})

main.up(1, 2, 3)
```
Demo: https://codepen.io/frenzzy/pen/KQeygR?editors=0010