### PR TITLE
Boolean attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,15 @@ export function app(state, actions, view, container) {
         } else {
           element.removeEventListener(name, eventListener)
         }
-      } else if (name in element && name !== "list" && name !== "type" && !isSvg) {
+      } else if (
+        name in element &&
+        name !== "list" &&
+        name !== "type" &&
+        name !== "draggable" &&
+        name !== "spellcheck" &&
+        name !== "translate" &&
+        !isSvg
+      ) {
         element[name] = value == null ? "" : value
       } else if (value != null && value !== false) {
         element.setAttribute(name, value)

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -652,3 +652,30 @@ testVdomToHtml("events", [
     html: `<button id="clicked"></button>`
   }
 ])
+
+testVdomToHtml("boolean attributes", [
+  {
+    vdom: (
+      <main>
+        <input
+          checked={true}
+          spellcheck="true"
+          autocomplete="on"
+          translate="yes"
+        />
+        <input
+          checked={false}
+          spellcheck="false"
+          autocomplete="off"
+          translate="no"
+        />
+      </main>
+    ),
+    html: `
+        <main>
+          <input spellcheck="true" autocomplete="on" translate="yes">
+          <input spellcheck="false" autocomplete="off" translate="no">
+        </main>
+      `
+  }
+])


### PR DESCRIPTION
Fixes #628

With this change we may rich consistent behavior between client and server rendering for reserved DOM attributes such as `spellcheck` or `draggable`, see:

before
```js
<input spellcheck="false" /> // => <input spellcheck="true" /> <== Oh NO!
<input spellcheck={false} /> // => <input spellcheck="false" />
```

after
```js
<input spellcheck="false" /> // => <input spellcheck="false" /> <== Oh YES!
<input spellcheck={false} /> // => <input spellcheck="false" />
```

SSR
```js
<input spellcheck="false" /> // => <input spellcheck="false" />
<input spellcheck={false} /> // => <input />
```