### PR TITLE
Allow Lazy components to return null as on the normal components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,11 @@ export function app(state, actions, view, container) {
   }
 
   function resolveNode(node) {
-    return typeof node === "function"
-      ? resolveNode(node(globalState, wiredActions)) || h(node, null)
-      : node
+    return node === null
+      ? h(node, null)
+      : typeof node === "function"
+        ? resolveNode(node(globalState, wiredActions)) || h(node, null)
+        : node
   }
 
   function render() {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export function h(name, attributes) {
       for (length = node.length; length--; ) {
         rest.push(node[length])
       }
-    } else if (node != null && node !== true && node !== false) {
+    } else if (node != null && node !== true && node !== false && node !== '') {
       children.push(node)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export function h(name, attributes) {
       for (length = node.length; length--; ) {
         rest.push(node[length])
       }
-    } else if (node != null && node !== true && node !== false && node !== '') {
+    } else if (node != null && node !== true && node !== false) {
       children.push(node)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export function app(state, actions, view, container) {
     return node === null
       ? h(node, null)
       : typeof node === "function"
-        ? resolveNode(node(globalState, wiredActions)) || h(node, null)
+        ? resolveNode(node(globalState, wiredActions))
         : node
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export function app(state, actions, view, container) {
 
   function resolveNode(node) {
     return typeof node === "function"
-      ? resolveNode(node(globalState, wiredActions)) || h(node(globalState, wiredActions), null))
+      ? resolveNode(node(globalState, wiredActions)) || h(node, null)
       : node
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,9 @@ export function h(name, attributes /*...rest*/) {
     }
   }
 
-  return typeof name === "function"
+  return name === null
+    ? null
+    : typeof name === "function"
     ? name(attributes || {}, children) // h(Component)
     : {
         nodeName: name,
@@ -57,10 +59,10 @@ export function app(state, actions, view, container) {
 
   function resolveNode(node) {
     return node === null
-      ? h(node, null)
-      : typeof node === "function"
-        ? resolveNode(node(globalState, wiredActions))
-        : node
+        ? h(node, null)
+        : typeof node === "function"
+          ? resolveNode(node(globalState, wiredActions))
+          : node
   }
 
   function render() {
@@ -167,6 +169,8 @@ export function app(state, actions, view, container) {
   }
 
   function createElement(node, isSVG) {
+    if(!node) return document.createDocumentFragment();
+
     var element =
       typeof node === "string" || typeof node === "number"
         ? document.createTextNode(node)
@@ -256,7 +260,7 @@ export function app(state, actions, view, container) {
   }
 
   function patch(parent, element, oldNode, node, isSVG) {
-    if (node === oldNode) {
+    if (node === oldNode || !node || !node && !element) {
     } else if (oldNode == null || oldNode.nodeName !== node.nodeName) {
       var newElement = createElement(node, isSVG)
       parent.insertBefore(newElement, element)

--- a/src/index.js
+++ b/src/index.js
@@ -55,9 +55,7 @@ export function app(state, actions, view, container) {
   function resolveNode(node) {
     return typeof node === "function"
       ? resolveNode(node(globalState, wiredActions))
-      : node != null 
-        ? node 
-        : ""
+      : node != null ? node : ""
   }
 
   function render() {

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export function app(state, actions, view, container) {
 
   function resolveNode(node) {
     return typeof node === "function"
-      ? resolveNode(node(globalState, wiredActions))
+      ? resolveNode(node(globalState, wiredActions)) || node
       : node
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export function app(state, actions, view, container) {
 
   function resolveNode(node) {
     return typeof node === "function"
-      ? resolveNode(node(globalState, wiredActions)) || node
+      ? resolveNode(node(globalState, wiredActions)) || h(node(globalState, wiredActions), null))
       : node
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,9 @@ export function app(state, actions, view, container) {
   function resolveNode(node) {
     return typeof node === "function"
       ? resolveNode(node(globalState, wiredActions))
-      : node || ''
+      : node != null 
+        ? node 
+        : ""
   }
 
   function render() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -63,3 +63,45 @@ test("lazy components", done => {
 
   app(state, actions, view, document.body)
 })
+
+
+test("returning null on a component", done => {
+  const nullComponent = () => () => null
+
+  const Component = () => () =>
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div></div>")
+          done()
+        }
+      },
+      [nullComponent]
+    )
+
+  const view = () => h(Component)
+
+  app(null, null, view, document.body)
+})
+
+
+test("returning null on a lazy component", done => {
+  const nullComponent = () => null
+
+  const Component = () => 
+    h(
+      "div",
+      {
+        oncreate() {
+          expect(document.body.innerHTML).toBe("<div></div>")
+          done()
+        }
+      },
+      [nullComponent]
+    )
+
+  const view = () => h(Component)
+
+  app(null, null, view, document.body)
+})

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -36,7 +36,6 @@ test("debouncing", done => {
   main.fire()
 })
 
-
 test("lazy components", done => {
   const state = { value: "foo" }
   const actions = {
@@ -64,11 +63,10 @@ test("lazy components", done => {
   app(state, actions, view, document.body)
 })
 
-
 test("returning null on a component", done => {
   const nullComponent = () => null
 
-  const Component = () => 
+  const Component = () =>
     h(
       "div",
       {
@@ -84,7 +82,6 @@ test("returning null on a component", done => {
 
   app(null, null, view, document.body)
 })
-
 
 test("returning null on a lazy component", done => {
   const nullComponent = () => () => null

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -66,9 +66,9 @@ test("lazy components", done => {
 
 
 test("returning null on a component", done => {
-  const nullComponent = () => () => null
+  const nullComponent = () => null
 
-  const Component = () => () =>
+  const Component = () => 
     h(
       "div",
       {
@@ -87,9 +87,9 @@ test("returning null on a component", done => {
 
 
 test("returning null on a lazy component", done => {
-  const nullComponent = () => null
+  const nullComponent = () => () => null
 
-  const Component = () => 
+  const Component = () => () =>
     h(
       "div",
       {


### PR DESCRIPTION
I was checking out the lazy components! I'm loving it!

I just found a little bug when you return null on a lazy component it will throw

```javascript
Uncaught TypeError: Cannot read property 'nodeName' of null on line 172
```

But this doesn't happen with normal components. So I had a look at the code and I realized that
resolveNode function will return null and so it means that node will be null
```javascript
  function resolveNode(node) {
    return typeof node === "function"
      ? resolveNode(node(globalState, wiredActions)) // will return undefined and will crash
      : node
  }
```

I fixed by just resolving normal node if the function is null like this:

```javascript
  function resolveNode(node) {
    return typeof node === "function"
      ? resolveNode(node(globalState, wiredActions)) || node
      : node
  }
```

I'm not sure if it's the best approach but I've been testing it and it works just fine.
Thanks for the lazy components it's awesome!!