### PR TITLE
Delegate DOM events to proxy.

### DIFF
--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -767,3 +767,20 @@ testTreeSegue("input list attribute", [
     html: `<input list="foobar">`
   }
 ])
+
+test("event handlers", done => {
+  app(
+    {},
+    {},
+    () =>
+      h("button", {
+        oncreate(element) {
+          element.dispatchEvent(new Event("click"))
+        },
+        onclick(event) {
+          done()
+        }
+      }),
+    document.body
+  )
+})


### PR DESCRIPTION
Instead of setting event handlers every time we patch the DOM like <samp>button.onclick = handler</samp> for every element, add a single event listener (only once) to every element with an event handler and only the first time we see it. 

Since all elements share the same listener, which merely acts as a proxy, we can expect moderate perf improvements, nothing like what #499 is aiming to do, but something.

This change also goes back to using addEventListener/removeEventListener, which may have some other favorable side effects like the ability to set certain events that only work via addEventListener (I can't find the issue now, perhaps it was a convo on Slack).

**+** 72 bytes 😅 