### PR TITLE
Add Size Limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 
 script:
   - npm test
+  - npm run size
   - codecov
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -24,17 +24,25 @@
     "bundle": "rollup -i src/index.js -o dist/hyperapp.js -m -f umd -n hyperapp",
     "minify": "uglifyjs dist/hyperapp.js -o dist/hyperapp.js -mc pure_funcs=['Object.defineProperty'] --source-map includeSources,url=hyperapp.js.map",
     "prepare": "npm run build",
+    "size": "npm run build && size-limit",
     "format": "prettier --semi false --write {src,test}/**/*.js {,test/ts/}*.{ts,tsx}",
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {
     "presets": "env"
   },
+  "size-limit": [
+    {
+      "path": "dist/hyperapp.js",
+      "limit": "1.3 KB"
+    }
+  ],
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
     "jest": "^22.2.0",
     "prettier": "^1.10.2",
     "rollup": "^0.55.3",
+    "size-limit": "^0.16.1",
     "typescript": "2.7.1",
     "uglify-js": "3.3.9"
   }


### PR DESCRIPTION
It is awesome, that you try to take care of library size. Maybe [Size Limit](https://github.com/ai/size-limit) could help you with it.

Size Limit is some sort of benchmark but for size.

It is a special tool to prevent JS libraries bloating. It calculates real cost of using the library as a dependency. It runs for every PR and will warn you if the size will be changed very quickly.

@jorgebucaran MobX, Autoprefixer, Material-UI uses it too.