### PR TITLE
Enter the dark side: rewrite some tests using JSX. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,18 @@
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {
-    "presets": "env"
+    "presets": "env",
+    "plugins": [
+      [
+        "transform-react-jsx",
+        {
+          "pragma": "h"
+        }
+      ]
+    ]
   },
   "devDependencies": {
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "jest": "^22.2.0",
     "prettier": "^1.10.2",

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -15,21 +15,18 @@ test("sync updates", done => {
     up: () => state => ({ value: state.value + 1 })
   }
 
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe(`<div>2</div>`)
-          done()
-        }
-      },
-      state.value
-    )
+  const view = state => (
+    <div
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe(`<div>2</div>`)
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
-  const main = app(state, actions, view, document.body)
-
-  main.up()
+  app(state, actions, view, document.body).up()
 })
 
 test("async updates", done => {
@@ -43,24 +40,21 @@ test("async updates", done => {
       mockDelay().then(() => actions.up(data))
   }
 
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe(`<div>2</div>`)
-        },
-        onupdate() {
-          expect(document.body.innerHTML).toBe(`<div>3</div>`)
-          done()
-        }
-      },
-      state.value
-    )
+  const view = state => (
+    <div
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe(`<div>2</div>`)
+      }}
+      onupdate={() => {
+        expect(document.body.innerHTML).toBe(`<div>3</div>`)
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
-  const main = app(state, actions, view, document.body)
-
-  main.upAsync(1)
+  app(state, actions, view, document.body).upAsync(1)
 })
 
 test("call action within action", done => {
@@ -80,23 +74,20 @@ test("call action within action", done => {
     })
   }
 
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(state).toEqual({
-            value: 2,
-            foo: true
-          })
-          expect(document.body.innerHTML).toBe(`<div>2</div>`)
-          done()
-        }
-      },
-      state.value
-    )
+  const view = state => (
+    <div
+      oncreate={() => {
+        expect(state).toEqual({
+          value: 2,
+          foo: true
+        })
+        expect(document.body.innerHTML).toBe(`<div>2</div>`)
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
-  const main = app(state, actions, view, document.body)
-
-  main.upAndFoo()
+  app(state, actions, view, document.body).upAndFoo()
 })

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5,9 +5,7 @@ beforeEach(() => {
 })
 
 test("debouncing", done => {
-  const state = {
-    value: 1
-  }
+  const state = { value: 1 }
 
   const actions = {
     up: () => state => ({ value: state.value + 1 }),
@@ -19,47 +17,40 @@ test("debouncing", done => {
     }
   }
 
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe("<div>5</div>")
-          done()
-        }
-      },
-      state.value
-    )
+  const view = state => (
+    <div
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe("<div>5</div>")
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
-  const main = app(state, actions, view, document.body)
-
-  main.fire()
+  app(state, actions, view, document.body).fire()
 })
 
-
-test("lazy components", done => {
+test("subviews / lazy components", done => {
   const state = { value: "foo" }
   const actions = {
     update: () => ({ value: "bar" })
   }
 
-  const Component = () => (state, actions) =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe("<div>foo</div>")
-          actions.update()
-        },
-        onupdate() {
-          expect(document.body.innerHTML).toBe("<div>bar</div>")
-          done()
-        }
-      },
-      state.value
-    )
+  const Component = () => (state, actions) => (
+    <div
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe("<div>foo</div>")
+        actions.update()
+      }}
+      onupdate={() => {
+        expect(document.body.innerHTML).toBe("<div>bar</div>")
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
-  const view = () => h(Component)
-
-  app(state, actions, view, document.body)
+  app(state, actions, <Component />, document.body)
 })

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -1,10 +1,8 @@
 import { h, app } from "../src"
 
-function testTreeSegue(name, trees) {
+const testVdomToHtml = (name, trees) => {
   test(name, done => {
-    const state = {
-      index: 0
-    }
+    const state = { index: 0 }
 
     const actions = {
       up: () => state => ({ index: state.index + 1 }),
@@ -21,38 +19,42 @@ function testTreeSegue(name, trees) {
       }
     }
 
-    const view = (state, actions) =>
-      h(
-        "main",
-        {
-          oncreate: actions.next,
-          onupdate: actions.next
-        },
-        [trees[state.index].tree]
-      )
+    const view = (state, actions) => (
+      <main oncreate={actions.next} onupdate={actions.next}>
+        {trees[state.index].vdom}
+      </main>
+    )
 
     app(state, actions, view, document.body)
   })
+}
+
+const setIdToKey = key => element => {
+  element.id = key
 }
 
 beforeEach(() => {
   document.body.innerHTML = ""
 })
 
-testTreeSegue("replace element", [
+testVdomToHtml("replace element", [
   {
-    tree: h("main", {}),
+    vdom: <main />,
     html: `<main></main>`
   },
   {
-    tree: h("div", {}),
+    vdom: <div />,
     html: `<div></div>`
   }
 ])
 
-testTreeSegue("replace child", [
+testVdomToHtml("replace child", [
   {
-    tree: h("main", {}, [h("div", {}, "foo")]),
+    vdom: (
+      <main>
+        <div>foo</div>
+      </main>
+    ),
     html: `
         <main>
           <div>foo</div>
@@ -60,7 +62,11 @@ testTreeSegue("replace child", [
       `
   },
   {
-    tree: h("main", {}, [h("main", {}, "bar")]),
+    vdom: (
+      <main>
+        <main>bar</main>
+      </main>
+    ),
     html: `
         <main>
           <main>bar</main>
@@ -69,20 +75,15 @@ testTreeSegue("replace child", [
   }
 ])
 
-testTreeSegue("insert children on top", [
+testVdomToHtml("insert children on top", [
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -90,19 +91,14 @@ testTreeSegue("insert children on top", [
       `
   },
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "b",
-          oncreate(e) {
-            e.id = "b"
-          }
-        },
-        "B"
-      ),
-      h("div", { key: "a" }, "A")
-    ]),
+    vdom: (
+      <main>
+        <div key="b" oncreate={setIdToKey("b")}>
+          B
+        </div>
+        <div key="a">A</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="b">B</div>
@@ -111,47 +107,17 @@ testTreeSegue("insert children on top", [
       `
   },
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "c",
-          oncreate(e) {
-            e.id = "c"
-          }
-        },
-        "C"
-      ),
-      h("div", { key: "b" }, "B"),
-      h("div", { key: "a" }, "A")
-    ]),
+    vdom: (
+      <main>
+        <div key="c" oncreate={setIdToKey("c")}>
+          C
+        </div>
+        <div key="b">B</div>
+        <div key="a">A</div>
+      </main>
+    ),
     html: `
         <main>
-          <div id="c">C</div>
-          <div id="b">B</div>
-          <div id="a">A</div>
-        </main>
-      `
-  },
-  {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "d",
-          oncreate(e) {
-            e.id = "d"
-          }
-        },
-        "D"
-      ),
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "b" }, "B"),
-      h("div", { key: "a" }, "A")
-    ]),
-    html: `
-        <main>
-          <div id="d">D</div>
           <div id="c">C</div>
           <div id="b">B</div>
           <div id="a">A</div>
@@ -160,9 +126,14 @@ testTreeSegue("insert children on top", [
   }
 ])
 
-testTreeSegue("remove text node", [
+testVdomToHtml("remove text node", [
   {
-    tree: h("main", {}, [h("div", {}, ["foo"]), "bar"]),
+    vdom: (
+      <main>
+        <div>foo</div>
+        bar
+      </main>
+    ),
     html: `
         <main>
           <div>foo</div>
@@ -171,7 +142,11 @@ testTreeSegue("remove text node", [
       `
   },
   {
-    tree: h("main", {}, [h("div", {}, ["foo"])]),
+    vdom: (
+      <main>
+        <div>foo</div>
+      </main>
+    ),
     html: `
         <main>
           <div>foo</div>
@@ -180,20 +155,15 @@ testTreeSegue("remove text node", [
   }
 ])
 
-testTreeSegue("replace keyed", [
+testVdomToHtml("replace keyed", [
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -201,18 +171,13 @@ testTreeSegue("replace keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "b",
-          oncreate(e) {
-            e.id = "b"
-          }
-        },
-        "B"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="b" oncreate={setIdToKey("b")}>
+          B
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="b">B</div>
@@ -221,60 +186,27 @@ testTreeSegue("replace keyed", [
   }
 ])
 
-testTreeSegue("reorder keyed", [
+testVdomToHtml("reorder keyed", [
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      ),
-      h(
-        "div",
-        {
-          key: "b",
-          oncreate(e) {
-            e.id = "b"
-          }
-        },
-        "B"
-      ),
-      h(
-        "div",
-        {
-          key: "c",
-          oncreate(e) {
-            e.id = "c"
-          }
-        },
-        "C"
-      ),
-      h(
-        "div",
-        {
-          key: "d",
-          oncreate(e) {
-            e.id = "d"
-          }
-        },
-        "D"
-      ),
-      h(
-        "div",
-        {
-          key: "e",
-          oncreate(e) {
-            e.id = "e"
-          }
-        },
-        "E"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+        <div key="b" oncreate={setIdToKey("b")}>
+          B
+        </div>
+        <div key="c" oncreate={setIdToKey("c")}>
+          C
+        </div>
+        <div key="d" oncreate={setIdToKey("d")}>
+          D
+        </div>
+        <div key="e" oncreate={setIdToKey("e")}>
+          E
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -286,13 +218,15 @@ testTreeSegue("reorder keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "e" }, "E"),
-      h("div", { key: "a" }, "A"),
-      h("div", { key: "b" }, "B"),
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "d" }, "D")
-    ]),
+    vdom: (
+      <main>
+        <div key="e">E</div>
+        <div key="a">A</div>
+        <div key="b">B</div>
+        <div key="c">C</div>
+        <div key="d">D</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="e">E</div>
@@ -304,13 +238,15 @@ testTreeSegue("reorder keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "e" }, "E"),
-      h("div", { key: "d" }, "D"),
-      h("div", { key: "a" }, "A"),
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "b" }, "B")
-    ]),
+    vdom: (
+      <main>
+        <div key="e">E</div>
+        <div key="d">D</div>
+        <div key="a">A</div>
+        <div key="c">C</div>
+        <div key="b">B</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="e">E</div>
@@ -322,13 +258,15 @@ testTreeSegue("reorder keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "e" }, "E"),
-      h("div", { key: "b" }, "B"),
-      h("div", { key: "a" }, "A"),
-      h("div", { key: "d" }, "D")
-    ]),
+    vdom: (
+      <main>
+        <div key="c">C</div>
+        <div key="e">E</div>
+        <div key="b">B</div>
+        <div key="a">A</div>
+        <div key="d">D</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="c">C</div>
@@ -341,60 +279,27 @@ testTreeSegue("reorder keyed", [
   }
 ])
 
-testTreeSegue("grow/shrink keyed", [
+testVdomToHtml("grow/shrink keyed", [
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      ),
-      h(
-        "div",
-        {
-          key: "b",
-          oncreate(e) {
-            e.id = "b"
-          }
-        },
-        "B"
-      ),
-      h(
-        "div",
-        {
-          key: "c",
-          oncreate(e) {
-            e.id = "c"
-          }
-        },
-        "C"
-      ),
-      h(
-        "div",
-        {
-          key: "d",
-          oncreate(e) {
-            e.id = "d"
-          }
-        },
-        "D"
-      ),
-      h(
-        "div",
-        {
-          key: "e",
-          oncreate(e) {
-            e.id = "e"
-          }
-        },
-        "E"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+        <div key="b" oncreate={setIdToKey("b")}>
+          B
+        </div>
+        <div key="c" oncreate={setIdToKey("c")}>
+          C
+        </div>
+        <div key="d" oncreate={setIdToKey("d")}>
+          D
+        </div>
+        <div key="e" oncreate={setIdToKey("e")}>
+          E
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -406,11 +311,13 @@ testTreeSegue("grow/shrink keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "a" }, "A"),
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "d" }, "D")
-    ]),
+    vdom: (
+      <main>
+        <div key="a">A</div>
+        <div key="c">C</div>
+        <div key="d">D</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -420,7 +327,11 @@ testTreeSegue("grow/shrink keyed", [
       `
   },
   {
-    tree: h("main", {}, [h("div", { key: "d" }, "D")]),
+    vdom: (
+      <main>
+        <div key="d">D</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="d">D</div>
@@ -428,49 +339,25 @@ testTreeSegue("grow/shrink keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      ),
-      h(
-        "div",
-        {
-          key: "b",
-          oncreate(e) {
-            e.id = "b"
-          }
-        },
-        "B"
-      ),
-      h(
-        "div",
-        {
-          key: "c",
-          oncreate(e) {
-            e.id = "c"
-          }
-        },
-        "C"
-      ),
-      h("div", { key: "d" }, "D"),
-      h(
-        "div",
-        {
-          key: "e",
-          oncreate(e) {
-            e.id = "e"
-          }
-        },
-        "E"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+        <div key="b" oncreate={setIdToKey("b")}>
+          B
+        </div>
+        <div key="c" oncreate={setIdToKey("c")}>
+          C
+        </div>
+        <div key="d" oncreate={setIdToKey("d")}>
+          D
+        </div>
+        <div key="e" oncreate={setIdToKey("e")}>
+          E
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -482,12 +369,14 @@ testTreeSegue("grow/shrink keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "d" }, "D"),
-      h("div", { key: "c" }, "C"),
-      h("div", { key: "b" }, "B"),
-      h("div", { key: "a" }, "A")
-    ]),
+    vdom: (
+      <main>
+        <div key="d">D</div>
+        <div key="c">C</div>
+        <div key="b">B</div>
+        <div key="a">A</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="d">D</div>
@@ -499,42 +388,23 @@ testTreeSegue("grow/shrink keyed", [
   }
 ])
 
-testTreeSegue("mixed keyed/non-keyed", [
+testVdomToHtml("mixed keyed/non-keyed", [
   {
-    tree: h("main", {}, [
-      h(
-        "div",
-        {
-          key: "a",
-          oncreate(e) {
-            e.id = "a"
-          }
-        },
-        "A"
-      ),
-      h("div", {}, "B"),
-      h("div", {}, "C"),
-      h(
-        "div",
-        {
-          key: "d",
-          oncreate(e) {
-            e.id = "d"
-          }
-        },
-        "D"
-      ),
-      h(
-        "div",
-        {
-          key: "e",
-          oncreate(e) {
-            e.id = "e"
-          }
-        },
-        "E"
-      )
-    ]),
+    vdom: (
+      <main>
+        <div key="a" oncreate={setIdToKey("a")}>
+          A
+        </div>
+        <div>B</div>
+        <div>C</div>
+        <div key="d" oncreate={setIdToKey("d")}>
+          D
+        </div>
+        <div key="e" oncreate={setIdToKey("e")}>
+          E
+        </div>
+      </main>
+    ),
     html: `
         <main>
           <div id="a">A</div>
@@ -546,13 +416,15 @@ testTreeSegue("mixed keyed/non-keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "e" }, "E"),
-      h("div", {}, "C"),
-      h("div", {}, "B"),
-      h("div", { key: "d" }, "D"),
-      h("div", { key: "a" }, "A")
-    ]),
+    vdom: (
+      <main>
+        <div key="e">E</div>
+        <div>C</div>
+        <div>B</div>
+        <div key="d">D</div>
+        <div key="a">A</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="e">E</div>
@@ -564,13 +436,15 @@ testTreeSegue("mixed keyed/non-keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", {}, "C"),
-      h("div", { key: "d" }, "D"),
-      h("div", { key: "a" }, "A"),
-      h("div", { key: "e" }, "E"),
-      h("div", {}, "B")
-    ]),
+    vdom: (
+      <main>
+        <div>C</div>
+        <div key="d">D</div>
+        <div key="a">A</div>
+        <div key="e">E</div>
+        <div>B</div>
+      </main>
+    ),
     html: `
         <main>
           <div>C</div>
@@ -582,12 +456,14 @@ testTreeSegue("mixed keyed/non-keyed", [
       `
   },
   {
-    tree: h("main", {}, [
-      h("div", { key: "e" }, "E"),
-      h("div", { key: "d" }, "D"),
-      h("div", {}, "B"),
-      h("div", {}, "C")
-    ]),
+    vdom: (
+      <main>
+        <div key="e">E</div>
+        <div key="d">D</div>
+        <div>B</div>
+        <div>C</div>
+      </main>
+    ),
     html: `
         <main>
           <div id="e">E</div>
@@ -599,188 +475,180 @@ testTreeSegue("mixed keyed/non-keyed", [
   }
 ])
 
-testTreeSegue("styles", [
+testVdomToHtml("styles", [
   {
-    tree: h("div"),
+    vdom: <div />,
     html: `<div></div>`
   },
   {
-    tree: h("div", { style: { color: "red", fontSize: "1em" } }),
+    vdom: <div style={{ color: "red", fontSize: "1em" }} />,
     html: `<div style="color: red; font-size: 1em;"></div>`
   },
   {
-    tree: h("div", { style: { color: "blue", float: "left" } }),
+    vdom: <div style={{ color: "blue", float: "left" }} />,
     html: `<div style="color: blue; float: left;"></div>`
   },
   {
-    tree: h("div"),
+    vdom: <div style="" />,
     html: `<div style=""></div>`
   }
 ])
 
-testTreeSegue("update element data", [
+testVdomToHtml("update element data", [
   {
-    tree: h("div", { id: "foo", class: "bar" }),
+    vdom: <div id="foo" class="bar" />,
     html: `<div id="foo" class="bar"></div>`
   },
   {
-    tree: h("div", { id: "foo", class: "baz" }),
+    vdom: <div id="foo" class="baz" />,
     html: `<div id="foo" class="baz"></div>`
   }
 ])
 
-testTreeSegue("removeAttribute", [
+testVdomToHtml("removeAttribute", [
   {
-    tree: h("div", { id: "foo", class: "bar" }),
+    vdom: <div id="foo" class="bar" />,
     html: `<div id="foo" class="bar"></div>`
   },
   {
-    tree: h("div"),
+    vdom: <div />,
     html: `<div></div>`
   }
 ])
 
-testTreeSegue("skip setAttribute for functions", [
+testVdomToHtml("skip setAttribute for functions", [
   {
-    tree: h("div", {
-      onclick() {}
-    }),
+    vdom: <div oncreate={() => {}} />,
     html: `<div></div>`
   }
 ])
 
-testTreeSegue("setAttribute true", [
+testVdomToHtml("setAttribute true", [
   {
-    tree: h("div", {
-      enabled: true
-    }),
+    vdom: <div enabled="true" />,
     html: `<div enabled="true"></div>`
   }
 ])
 
-testTreeSegue("update element with dynamic props", [
+testVdomToHtml("a list with empty text nodes", [
   {
-    tree: h("input", {
-      type: "text",
-      value: "foo",
-      oncreate(element) {
-        expect(element.value).toBe("foo")
-      }
-    }),
-    html: `<input type="text">`
-  },
-  {
-    tree: h("input", {
-      type: "text",
-      value: "bar",
-      onupdate(element) {
-        expect(element.value).toBe("bar")
-      }
-    }),
-    html: `<input type="text">`
-  }
-])
-
-testTreeSegue("don't touch textnodes if equal", [
-  {
-    tree: h(
-      "main",
-      {
-        oncreate(element) {
-          element.childNodes[0].textContent = "foobar"
-        }
-      },
-      "foo"
+    vdom: (
+      <ul>
+        <li />
+        <div>foo</div>
+      </ul>
     ),
-    html: `<main>foobar</main>`
-  },
-  {
-    tree: h("main", {}, "foobar"),
-    html: `<main>foobar</main>`
-  }
-])
-
-testTreeSegue("a list with empty text nodes", [
-  {
-    tree: h("ul", {}, [h("li", {}, ""), h("div", {}, "foo")]),
     html: `<ul><li></li><div>foo</div></ul>`
   },
   {
-    tree: h("ul", {}, [h("li", {}, ""), h("li", {}, ""), h("div", {}, "foo")]),
+    vdom: (
+      <ul>
+        <li />
+        <li />
+        <div>foo</div>
+      </ul>
+    ),
     html: `<ul><li></li><li></li><div>foo</div></ul>`
   },
   {
-    tree: h("ul", {}, [
-      h("li", {}, ""),
-      h("li", {}, ""),
-      h("li", {}, ""),
-      h("div", {}, "foo")
-    ]),
+    vdom: (
+      <ul>
+        <li />
+        <li />
+        <li />
+        <div>foo</div>
+      </ul>
+    ),
     html: `<ul><li></li><li></li><li></li><div>foo</div></ul>`
   }
 ])
 
-testTreeSegue("elements with falsey values", [
+testVdomToHtml("elements with falsey values", [
   {
-    tree: h("div", {
-      "data-test": "foo"
-    }),
-    html: `<div data-test="foo"></div>`
-  },
-  {
-    tree: h("div", {
-      "data-test": "0"
-    }),
+    vdom: <div data-test={"0"} />,
     html: `<div data-test="0"></div>`
   },
   {
-    tree: h("div", {
-      "data-test": 0
-    }),
+    vdom: <div data-test={0} />,
     html: `<div data-test="0"></div>`
   },
   {
-    tree: h("div", {
-      "data-test": null
-    }),
+    vdom: <div data-test={null} />,
     html: `<div></div>`
   },
   {
-    tree: h("div", {
-      "data-test": false
-    }),
+    vdom: <div data-test={false} />,
     html: `<div></div>`
   },
   {
-    tree: h("div", {
-      "data-test": undefined
-    }),
+    vdom: <div data-test={undefined} />,
     html: `<div></div>`
   }
 ])
 
-testTreeSegue("input list attribute", [
+testVdomToHtml("update element with dynamic props", [
   {
-    tree: h("input", {
-      list: "foobar"
-    }),
+    vdom: (
+      <input
+        type="text"
+        value="foo"
+        onupdate={element => {
+          expect(element.value).toBe("foo")
+        }}
+      />
+    ),
+    html: `<input type="text">`
+  },
+  {
+    vdom: (
+      <input
+        type="text"
+        value="bar"
+        onupdate={element => {
+          expect(element.value).toBe("bar")
+        }}
+      />
+    ),
+    html: `<input type="text">`
+  }
+])
+
+testVdomToHtml("don't touch textnodes if equal", [
+  {
+    vdom: (
+      <main
+        oncreate={e => {
+          e.childNodes[0].textContent = "foobar"
+        }}
+      >
+        foobar
+      </main>
+    ),
+    html: `<main>foobar</main>`
+  },
+  {
+    vdom: <main>foobar</main>,
+    html: `<main>foobar</main>`
+  }
+])
+
+testVdomToHtml("input list attribute", [
+  {
+    vdom: <input list="foobar" />,
     html: `<input list="foobar">`
   }
 ])
 
-test("event handlers", done => {
-  app(
-    {},
-    {},
-    () =>
-      h("button", {
-        oncreate(element) {
-          element.dispatchEvent(new Event("click"))
-        },
-        onclick(event) {
-          done()
-        }
-      }),
-    document.body
-  )
-})
+testVdomToHtml("events", [
+  {
+    vdom: (
+      <button
+        oncreate={element => element.dispatchEvent(new Event("click"))}
+        onclick={event => {
+          event.currentTarget.id = "clicked"
+        }}
+      />
+    ),
+    html: `<button id="clicked"></button>`
+  }
+])

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -5,20 +5,22 @@ beforeEach(() => {
 })
 
 test("oncreate", done => {
-  const view = () =>
-    h(
-      "div",
-      {
-        oncreate(element) {
+  app(
+    {},
+    {},
+    () => (
+      <div
+        oncreate={element => {
           element.className = "foo"
           expect(document.body.innerHTML).toBe(`<div class="foo">foo</div>`)
           done()
-        }
-      },
-      "foo"
-    )
-
-  app({}, {}, view, document.body)
+        }}
+      >
+        foo
+      </div>
+    ),
+    document.body
+  )
 })
 
 test("onupdate", done => {
@@ -27,22 +29,21 @@ test("onupdate", done => {
     setValue: value => ({ value })
   }
 
-  const view = (state, actions) =>
-    h(
-      "div",
-      {
-        class: state.value,
-        oncreate() {
-          actions.setValue("bar")
-        },
-        onupdate(element, oldProps) {
-          expect(element.textContent).toBe("bar")
-          expect(oldProps.class).toBe("foo")
-          done()
-        }
-      },
-      state.value
-    )
+  const view = (state, actions) => (
+    <div
+      class={state.value}
+      oncreate={() => {
+        actions.setValue("bar")
+      }}
+      onupdate={(element, oldProps) => {
+        expect(element.textContent).toBe("bar")
+        expect(oldProps.class).toBe("foo")
+        done()
+      }}
+    >
+      {state.value}
+    </div>
+  )
 
   app(state, actions, view, document.body)
 })
@@ -57,29 +58,27 @@ test("onremove", done => {
   }
 
   const view = (state, actions) =>
-    state.value
-      ? h(
-          "ul",
-          {
-            oncreate() {
-              expect(document.body.innerHTML).toBe(
-                "<ul><li></li><li></li></ul>"
-              )
-              actions.toggle()
-            }
-          },
-          [
-            h("li"),
-            h("li", {
-              onremove(element, remove) {
-                remove()
-                expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
-                done()
-              }
-            })
-          ]
-        )
-      : h("ul", {}, [h("li")])
+    state.value ? (
+      <ul
+        oncreate={() => {
+          expect(document.body.innerHTML).toBe("<ul><li></li><li></li></ul>")
+          actions.toggle()
+        }}
+      >
+        <li />
+        <li
+          onremove={(element, remove) => {
+            remove()
+            expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
+            done()
+          }}
+        />
+      </ul>
+    ) : (
+      <ul>
+        <li />
+      </ul>
+    )
 
   app(state, actions, view, document.body)
 })
@@ -96,25 +95,27 @@ test("ondestroy", done => {
   }
 
   const view = (state, actions) =>
-    state.value
-      ? h(
-          "ul",
-          {
-            oncreate: () => actions.toggle()
-          },
-          [
-            h("li"),
-            h("li", {}, [
-              h("span", {
-                ondestroy() {
-                  expect(removed).toBe(false)
-                  done()
-                }
-              })
-            ])
-          ]
-        )
-      : h("ul", {}, [h("li")])
+    state.value ? (
+      <ul
+        oncreate={() => {
+          actions.toggle()
+        }}
+      >
+        <li />
+        <li>
+          <span
+            ondestroy={() => {
+              expect(removed).toBe(false)
+              done()
+            }}
+          />
+        </li>
+      </ul>
+    ) : (
+      <ul>
+        <li />
+      </ul>
+    )
 
   app(state, actions, view, document.body)
 })
@@ -131,30 +132,30 @@ test("onremove/ondestroy", done => {
   }
 
   const view = (state, actions) =>
-    state.value
-      ? h(
-          "ul",
-          {
-            oncreate() {
-              actions.toggle()
-            }
-          },
-          [
-            h("li"),
-            h("li", {
-              ondestroy() {
-                detached = true
-              },
-              onremove(element, remove) {
-                expect(detached).toBe(false)
-                remove()
-                expect(detached).toBe(true)
-                done()
-              }
-            })
-          ]
-        )
-      : h("ul", {}, [h("li")])
+    state.value ? (
+      <ul
+        oncreate={() => {
+          actions.toggle()
+        }}
+      >
+        <li />
+        <li
+          ondestroy={() => {
+            detached = true
+          }}
+          onremove={(element, remove) => {
+            expect(detached).toBe(false)
+            remove()
+            expect(detached).toBe(true)
+            done()
+          }}
+        />
+      </ul>
+    ) : (
+      <ul>
+        <li />
+      </ul>
+    )
 
   app(state, actions, view, document.body)
 })
@@ -170,46 +171,45 @@ test("event bubbling", done => {
     toggle: () => state => ({ value: !state.value })
   }
 
-  const view = (state, actions) =>
-    h(
-      "main",
-      {
-        oncreate() {
-          expect(count++).toBe(3)
-          actions.toggle()
-        },
-        onupdate() {
-          expect(count++).toBe(7)
-          done()
-        }
-      },
-      [
-        h("p", {
-          oncreate() {
-            expect(count++).toBe(2)
-          },
-          onupdate() {
-            expect(count++).toBe(6)
-          }
-        }),
-        h("p", {
-          oncreate() {
-            expect(count++).toBe(1)
-          },
-          onupdate() {
-            expect(count++).toBe(5)
-          }
-        }),
-        h("p", {
-          oncreate() {
-            expect(count++).toBe(0)
-          },
-          onupdate() {
-            expect(count++).toBe(4)
-          }
-        })
-      ]
-    )
+  const view = (state, actions) => (
+    <main
+      oncreate={() => {
+        expect(count++).toBe(3)
+        actions.toggle()
+      }}
+      onupdate={() => {
+        expect(count++).toBe(7)
+        done()
+      }}
+    >
+      <p
+        oncreate={() => {
+          expect(count++).toBe(2)
+        }}
+        onupdate={() => {
+          expect(count++).toBe(6)
+        }}
+      />
+
+      <p
+        oncreate={() => {
+          expect(count++).toBe(1)
+        }}
+        onupdate={() => {
+          expect(count++).toBe(5)
+        }}
+      />
+
+      <p
+        oncreate={() => {
+          expect(count++).toBe(0)
+        }}
+        onupdate={() => {
+          expect(count++).toBe(4)
+        }}
+      />
+    </main>
+  )
 
   app(state, actions, view, document.body)
 })

--- a/test/mounting.test.js
+++ b/test/mounting.test.js
@@ -10,40 +10,42 @@ test("headless", done => {
 
 test("container", done => {
   document.body.innerHTML = "<main></main>"
-
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
+  app(
+    {},
+    {},
+    () => (
+      <div
+        oncreate={() => {
           expect(document.body.innerHTML).toBe("<main><div>foo</div></main>")
           done()
-        }
-      },
-      "foo"
-    )
-
-  app({}, {}, view, document.body.firstChild)
+        }}
+      >
+        foo
+      </div>
+    ),
+    document.body.firstChild
+  )
 })
 
 test("nested container", done => {
   document.body.innerHTML = "<main><section></section><div></div></main>"
-
-  const view = state =>
-    h(
-      "p",
-      {
-        oncreate() {
+  app(
+    {},
+    {},
+    () => (
+      <p
+        oncreate={() => {
           expect(document.body.innerHTML).toBe(
             `<main><section></section><div><p>foo</p></div></main>`
           )
           done()
-        }
-      },
-      "foo"
-    )
-
-  app({}, {}, view, document.body.firstChild.lastChild)
+        }}
+      >
+        foo
+      </p>
+    ),
+    document.body.firstChild.lastChild
+  )
 })
 
 test("container with mutated host", done => {
@@ -60,28 +62,27 @@ test("container with mutated host", done => {
     bar: () => ({ value: "bar" })
   }
 
-  const view = (state, actions) =>
-    h(
-      "p",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe(
-            `<main><div><p>foo</p></div></main>`
-          )
-          host.insertBefore(document.createElement("header"), host.firstChild)
-          host.appendChild(document.createElement("footer"))
+  const view = (state, actions) => (
+    <p
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe(
+          `<main><div><p>foo</p></div></main>`
+        )
+        host.insertBefore(document.createElement("header"), host.firstChild)
+        host.appendChild(document.createElement("footer"))
 
-          actions.bar()
-        },
-        onupdate() {
-          expect(document.body.innerHTML).toBe(
-            `<main><header></header><div><p>bar</p></div><footer></footer></main>`
-          )
-          done()
-        }
-      },
-      state.value
-    )
+        actions.bar()
+      }}
+      onupdate={() => {
+        expect(document.body.innerHTML).toBe(
+          `<main><header></header><div><p>bar</p></div><footer></footer></main>`
+        )
+        done()
+      }}
+    >
+      {state.value}
+    </p>
+  )
 
   app(state, actions, view, container)
 })

--- a/test/recycling.test.js
+++ b/test/recycling.test.js
@@ -1,48 +1,52 @@
 import { h, app } from "../src"
 
 test("recycle markup", done => {
-  const SSR_BODY = `<div id="app"><main><p id="foo">foo</p></main></div>`
+  const SSR_HTML = `<div id="app"><main><p id="foo">foo</p></main></div>`
 
-  document.body.innerHTML = SSR_BODY
+  document.body.innerHTML = SSR_HTML
 
-  const view = state =>
-    h("main", {}, [
-      h(
-        "p",
-        {
-          oncreate(element) {
+  app(
+    null,
+    null,
+    state => (
+      <main>
+        <p
+          oncreate={element => {
             expect(element.id).toBe("foo")
-            expect(document.body.innerHTML).toBe(SSR_BODY)
+            expect(document.body.innerHTML).toBe(SSR_HTML)
             done()
-          }
-        },
-        "foo"
-      )
-    ])
-
-  app({}, {}, view, document.getElementById("app"))
+          }}
+        >
+          foo
+        </p>
+      </main>
+    ),
+    document.getElementById("app")
+  )
 })
 
 test("recycle markup against keyed vdom", done => {
-  const SSR_BODY = `<div id="app"><main><p id="foo">foo</p></main></div>`
+  const SSR_HTML = `<div id="app"><main><p id="foo">foo</p></main></div>`
 
-  document.body.innerHTML = SSR_BODY
+  document.body.innerHTML = SSR_HTML
 
-  const view = state =>
-    h("main", {}, [
-      h(
-        "p",
-        {
-          key: "key",
-          oncreate(element) {
+  app(
+    null,
+    null,
+    state => (
+      <main>
+        <p
+          key="someKey"
+          oncreate={element => {
             expect(element.id).toBe("foo")
-            expect(document.body.innerHTML).toBe(SSR_BODY)
+            expect(document.body.innerHTML).toBe(SSR_HTML)
             done()
-          }
-        },
-        "foo"
-      )
-    ])
-
-  app({}, {}, view, document.getElementById("app"))
+          }}
+        >
+          foo
+        </p>
+      </main>
+    ),
+    document.getElementById("app")
+  )
 })

--- a/test/slices.test.js
+++ b/test/slices.test.js
@@ -25,9 +25,7 @@ test("slices", done => {
     }
   }
 
-  const state = {
-    foo: foo.state
-  }
+  const state = { foo: foo.state }
 
   const actions = {
     foo: foo.actions,
@@ -52,34 +50,30 @@ test("slices", done => {
 })
 
 test("state/actions tree", done => {
-  const state = {
-    foo: {}
-  }
+  const state = { foo: {} }
 
   const actions = {
     foo: {
       bar: {
         baz: {
-          foobarbaz: () => ({ value: "foobarbaz" })
+          fooBarBaz: () => ({ value: "foobarbaz" })
         }
       }
     }
   }
 
-  const view = state =>
-    h(
-      "div",
-      {
-        oncreate() {
-          expect(document.body.innerHTML).toBe(`<div>foobarbaz</div>`)
-          done()
-        }
-      },
-      state.foo.bar.baz.value
-    )
+  const view = state => (
+    <div
+      oncreate={() => {
+        expect(document.body.innerHTML).toBe(`<div>foobarbaz</div>`)
+        done()
+      }}
+    >
+      {state.foo.bar.baz.value}
+    </div>
+  )
 
-  const main = app(state, actions, view, document.body)
+  app(state, actions, view, document.body).foo.bar.baz.fooBarBaz()
 
-  main.foo.bar.baz.foobarbaz()
   expect(state).toEqual({ foo: {} })
 })

--- a/test/svg.test.js
+++ b/test/svg.test.js
@@ -9,41 +9,29 @@ const deepExpectNS = (element, ns) =>
   })
 
 test("svg", done => {
-  const view = () =>
-    h(
-      "div",
-      {
-        oncreate() {
-          const foo = document.getElementById("foo")
-          const bar = document.getElementById("bar")
-          const baz = document.getElementById("baz")
+  const view = () => (
+    <div
+      oncreate={() => {
+        const foo = document.getElementById("foo")
+        const bar = document.getElementById("bar")
+        const baz = document.getElementById("baz")
 
-          expect(foo.namespaceURI).not.toBe(SVG_NS)
-          expect(baz.namespaceURI).not.toBe(SVG_NS)
-          expect(bar.namespaceURI).toBe(SVG_NS)
-          expect(bar.getAttribute("viewBox")).toBe("0 0 10 10")
-          deepExpectNS(bar, SVG_NS)
+        expect(foo.namespaceURI).not.toBe(SVG_NS)
+        expect(baz.namespaceURI).not.toBe(SVG_NS)
+        expect(bar.namespaceURI).toBe(SVG_NS)
+        expect(bar.getAttribute("viewBox")).toBe("0 0 10 10")
+        deepExpectNS(bar, SVG_NS)
 
-          done()
-        }
-      },
-      [
-        h("p", { id: "foo" }, "foo"),
-        h("svg", { id: "bar", viewBox: "0 0 10 10" }, [
-          h("quux", {}, [
-            h("beep", {}, [h("ping", {}), h("pong", {})]),
-            h("bop", {}),
-            h("boop", {}, [h("ping", {}), h("pong", {})])
-          ]),
-          h("xuuq", {}, [
-            h("beep", {}),
-            h("bop", {}, [h("ping", {}), h("pong", {})]),
-            h("boop", {})
-          ])
-        ]),
-        h("p", { id: "baz" }, "baz")
-      ]
-    )
+        done()
+      }}
+    >
+      <p id="foo">foo</p>
+      <svg id="bar" viewBox="0 0 10 10">
+        <foo />
+      </svg>
+      <p id="baz">baz</p>
+    </div>
+  )
 
-  app({}, {}, view, document.body)
+  app(null, null, view, document.body)
 })


### PR DESCRIPTION
Use JSX in tests (like I used to back in the day). I tried to fall in love with `h`, but old habits kept getting in the way. I confess I personally find JSX a lot easier to understand than nested `h` calls. Perhaps my brain is wired to look at HTML-like trees and instantly visualize what's going on. Sorry, JSX detractors, I just can't get used to `h`. 

> P.S: `@hyperapp/html` is also a valid alternative, but it's easier to use JSX with Jest and since we're using Jest... 

![](https://user-images.githubusercontent.com/56996/37108748-61397b58-227b-11e8-80e8-bd7a80de5072.jpg)
