### PR TITLE
Keyed children diff optimization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -320,9 +320,18 @@ export function app(state, actions, view, container) {
 
       while (k < children.length) {
         var oldKey = getKey(oldChildren[i])
+        var nextOldKey = getKey(oldChildren[i + 1])
         var newKey = getKey((children[k] = resolveNode(children[k])))
 
         if (newKeyed[oldKey]) {
+          i++
+          continue
+        }
+
+        if (newKey != null && newKey === nextOldKey) {
+          if (oldKey == null) {
+            removeElement(element, oldElements[i], oldChildren[i])
+          }
           i++
           continue
         }

--- a/src/index.js
+++ b/src/index.js
@@ -320,7 +320,6 @@ export function app(state, actions, view, container) {
 
       while (k < children.length) {
         var oldKey = getKey(oldChildren[i])
-        var nextOldKey = getKey(oldChildren[i + 1])
         var newKey = getKey((children[k] = resolveNode(children[k])))
 
         if (newKeyed[oldKey]) {
@@ -328,7 +327,7 @@ export function app(state, actions, view, container) {
           continue
         }
 
-        if (newKey != null && newKey === nextOldKey) {
+        if (newKey != null && newKey === getKey(oldChildren[i + 1])) {
           if (oldKey == null) {
             removeElement(element, oldElements[i], oldChildren[i])
           }


### PR DESCRIPTION
### Summary of the change
 1.  Determine if the new keyed child matches the next old child (thanks to `preact` for the inspiration here).
 2. If the current old child is keyed, leave it alone.
 3. If the current old child is non-keyed, remove it.  This keeps the "mixed keyed/nonkeyed" test happy.
 4. Increment the old children index and go back to the start of the while loop.

### Benefits
 * Closes #660: Keyed `<input>` stays focused if siblings before it are removed ([Proof on Codepen](https://codepen.io/SkaterDad/pen/KoXzwN)).  I tried writing test cases for this, but the `<input>` never fired a "blur" event like it did in-browser.
 * Better keyed list modification performance.  Results in fewer "insertBefore" calls when a keyed item is removed but other items are in the same order.  Open the "Details" below to see a screenshot from `JS Framework Benchmark`.  Row removal is 2x faster.  Row swap is 5x faster.

     <details>

      ![image](https://user-images.githubusercontent.com/13255599/37878122-9efb84d4-3029-11e8-82f0-181f3b27bca3.png)

     </details>



### Bytes
Minified file size changes from 3.45KB to 3.51KB.
Gzipped file size changes from 1.54KB to 1.56KB (using default options in linux gzip command).

> Edit:  Added benchmark screenshot.