### PR TITLE
Format improvements

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -18,7 +18,9 @@ export interface VNode<Attributes = {}> {
  * @memberOf [VDOM]
  */
 export interface Component<Attributes = {}, State = {}, Actions = {}> {
-  (attributes: Attributes, children: Array<VNode | string>): VNode<Attributes> | View<State, Actions>
+  (attributes: Attributes, children: Array<VNode | string>):
+    | VNode<Attributes>
+    | View<State, Actions>
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bundle": "rollup -i src/index.js -o dist/hyperapp.js -m -f umd -n hyperapp",
     "minify": "uglifyjs dist/hyperapp.js -o dist/hyperapp.js -mc pure_funcs=['Object.defineProperty'] --source-map includeSources,url=hyperapp.js.map",
     "prepare": "npm run build",
-    "format": "prettier --semi false --write {src,test}/**/*.js {,test/ts/}*.{ts,tsx}",
+    "format": "prettier --write {src,test}/**/*.js {,test/ts/}*.{ts,tsx}",
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {
@@ -49,5 +49,8 @@
     "rollup": "^0.55.3",
     "typescript": "2.7.1",
     "uglify-js": "3.3.9"
+  },
+  "prettier": {
+    "semi": false
   }
 }

--- a/test/ts/Component.tsx
+++ b/test/ts/Component.tsx
@@ -9,16 +9,21 @@ interface Actions {
   up(value: number): State
 }
 
-const Counter: Component<{ state: State, actions: Actions }> = ({ state, actions }) =>
+const Counter: Component<{ state: State; actions: Actions }> = ({
+  state,
+  actions
+}) => (
   <div>
     <div>{state.count}</div>
     <button onclick={actions.down}>-</button>
     <button onclick={actions.up}>+</button>
   </div>
+)
 
-const LazyCounter: Component<{}, State, Actions> = () => (state, actions) =>
+const LazyCounter: Component<{}, State, Actions> = () => (state, actions) => (
   <div>
     <div>{state.count}</div>
     <button onclick={actions.down}>-</button>
     <button onclick={actions.up}>+</button>
   </div>
+)


### PR DESCRIPTION
Since I'm using [`prettier`](https://prettier.io) in my editor with format on save enabled - I noticed that our configuration for `prettier` is sent as a command line argument instead of stored in the `"prettier"` property of our `package.json` (or we could have a [`.prettierrc`](https://prettier.io/docs/en/configuration.html) if you'd rather add a new file). Having this encourages folks to keep auto format enabled in their editors, which will eliminate the problem of forgetting to format the code. I'm already using this config in [`@hyperapp/logger`](https://github.com/hyperapp/logger/blob/634e52ba8ae9fc6c2b38271ba15bdd9d2aabdbfc/package.json#L29) and [`@hyperapp/fx`](https://github.com/hyperapp/fx/blob/80d20cb6356644af37991cd2561340f63f9e0d0f/package.json#L38).

Also, some of the existing code wasn't formatted, so I'm including that fix.