### PR TITLE
Make npm scripts steps more obvious

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,17 @@
     "vdom"
   ],
   "scripts": {
-    "test": "jest --coverage --no-cache && tsc -p test/ts",
-    "build": "npm run bundle && npm run minify",
+    "test": "jest --coverage --no-cache",
+    "posttest": "tsc -p test/ts",
+    "build": "npm run bundle",
+    "postbuild": "npm run minify",
     "bundle": "rollup -i src/index.js -o dist/hyperapp.js -m -f umd -n hyperapp",
     "minify": "uglifyjs dist/hyperapp.js -o dist/hyperapp.js -mc pure_funcs=['Object.defineProperty'] --source-map includeSources,url=hyperapp.js.map",
     "prepare": "npm run build",
     "format": "prettier --write {src,test}/**/*.js {,test/ts/}*.{ts,tsx}",
-    "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
+    "prerelease": "npm test && npm run build",
+    "release": "git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags",
+    "postrelease": "npm publish"
   },
   "babel": {
     "presets": "env",


### PR DESCRIPTION
The use will stay the same, but npm/yarn will log clearly each step (pre, cmd, post).

Example : 
```zsh
$ npm run build

> npm run bundle && npm run minify
# npm run bundle logs
# npm run minify logs
``` 
Will be
```zsh
$ npm run build

> npm run bundle
# npm run bundle logs

> npm run minify
# npm run minify logs
``` 