### PR TITLE
Inline styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ export function app(state, actions, view, container) {
 
   function updateAttribute(element, name, value, oldValue, isSvg) {
     if (name === "key") {
-    } else if (name === "style") {
+    } else if (name === "style" && typeof value === "object") {
       for (var i in clone(oldValue, value)) {
         var style = value == null || value[i] == null ? "" : value[i]
         if (i[0] === "-") {

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -494,6 +494,33 @@ testVdomToHtml("styles", [
   }
 ])
 
+testVdomToHtml("inline styles", [
+  {
+    vdom: <div />,
+    html: `<div></div>`
+  },
+  {
+    vdom: <div style="color:red;font-size:1em;--foo:red" />,
+    html: `<div style="color: red; font-size: 1em;"></div>`
+  },
+  {
+    vdom: <div style="color:blue;float:left;--foo:blue" />,
+    html: `<div style="color: blue; float: left;"></div>`
+  },
+  {
+    vdom: <div style="" />,
+    html: `<div style=""></div>`
+  },
+  {
+    vdom: <div style={null} />,
+    html: `<div style=""></div>`
+  },
+  {
+    vdom: <div />,
+    html: `<div></div>`
+  }
+])
+
 testVdomToHtml("update element data", [
   {
     vdom: <div id="foo" class="bar" />,


### PR DESCRIPTION
It allows us to use bunch of valid html/svg code inside vdom tree without the need to convert a lot of inline styles into objects.

Fixes https://github.com/hyperapp/hyperapp/issues/672#issuecomment-377783572

Demo: https://codepen.io/frenzzy/pen/OvEyeL/left/?editors=0010