### PR TITLE
Fix typing issue with Component<>

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -20,7 +20,6 @@ export interface VNode<Attributes = {}> {
 export interface Component<Attributes = {}, State = {}, Actions = {}> {
   (attributes: Attributes, children: Array<VNode | string>):
     | VNode<Attributes>
-    | View<State, Actions>
 }
 
 /**

--- a/test/ts/index.tsx
+++ b/test/ts/index.tsx
@@ -1,25 +1,25 @@
-import { h, app, ActionsType, View } from "hyperapp"
+import { h, app, ActionsType, View, Component, VNode } from 'hyperapp';
 
 namespace Counter {
   export interface State {
-    count: number
+    count: number;
   }
 
   export interface Actions {
-    down(): State
-    up(value: number): State
+    down(): State;
+    up(value: number): State;
   }
 
   export const state: State = {
-    count: 0
-  }
+    count: 0,
+  };
 
   export const actions: ActionsType<State, Actions> = {
-    down: () => state => ({ count: state.count - 1 }),
-    up: (value: number) => state => ({
-      count: state.count + value
-    })
-  }
+    down: () => (state) => ({ count: state.count - 1 }),
+    up: (value: number) => (state) => ({
+      count: state.count + value,
+    }),
+  };
 }
 
 const view: View<Counter.State, Counter.Actions> = (state, actions) => (
@@ -28,11 +28,21 @@ const view: View<Counter.State, Counter.Actions> = (state, actions) => (
     <button onclick={actions.down}>-</button>
     <button onclick={actions.up}>+</button>
   </main>
-)
+);
+
+const comp: Component<{}, Counter.State, Counter.Actions> = (
+  attributes: {},
+  children: Array<VNode | string>
+) => {
+  return h('div', {}, 'component');
+};
+
+const view2: View<Counter.State, Counter.Actions> = (state, actions) =>
+  h('div', {}, [comp({}, [])]);
 
 app<Counter.State, Counter.Actions>(
   Counter.state,
   Counter.actions,
   view,
   document.body
-)
+);


### PR DESCRIPTION
Fixes #714

`Component` return type is `VNode<Attributes> | View<State, Actions>`. These
two aren't compatible with each other. Therefore the `Component` can only be a
function that returns a `VNode`. This has to do with the `h` only returning a
`VNode<Attributes>`.

Another fix could be to allow `h<Attributes()` to return `VNode<..> | View<..>`
but this will trickle down other issues with the typings.

This way there is a distinct way of creating a `VNode` from `Component` and
creating the `View(state, actions)` function typed as `View<TState, TActions>`