### PR TITLE
add sandbox

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>hyperapp</title>
+</head>
+<body>
+</body>
+</html>

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sandbox",
+  "version": "1.0.0",
+  "description": "sandbox for hyperapp",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --mode development"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
+    "css-loader": "^1.0.0",
+    "html-webpack-plugin": "^3.2.0",
+    "prettier": "^1.14.2",
+    "style-loader": "^0.22.1",
+    "webpack": "^4.16.5",
+    "webpack-cli": "^3.1.0",
+    "webpack-dev-server": "^3.1.5"
+  }
+}

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -1,0 +1,54 @@
+body {
+  align-items: center;
+  background-color: #111;
+  display: flex;
+  font-family: Helvetica Neue, sans-serif;
+  height: 100vh;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  line-height: 1;
+  text-align: center;
+  color: #00caff;
+}
+
+h1 {
+  color: inherit;
+  font-weight: 100;
+  font-size: 8em;
+  margin: 0;
+  padding-bottom: 15px;
+}
+
+button {
+  background: #111;
+  border-radius: 0px;
+  border: 1px solid #00caff;
+  color: inherit;
+  font-size: 2em;
+  font-weight: 100;
+  line-height: inherit;
+  margin: 0;
+  outline: none;
+  padding: 5px 15px 10px;
+  transition: background .2s;
+}
+
+button:hover,
+button:active,
+button:disabled {
+  background: #00caff;
+  color: #111;
+}
+
+button:active {
+  outline: 2px solid #00caff;
+}
+
+button:focus {
+  border: 1px solid #00caff;
+}
+
+button + button {
+  margin-left: 3px;
+}

--- a/sandbox/src/index.js
+++ b/sandbox/src/index.js
@@ -1,0 +1,33 @@
+import { h, app } from "hyperapp"
+import * as style from "./index.css"
+// @jsx h
+
+const state = {
+  count: 0
+}
+
+const actions = {
+  down: value => state => ({ count: state.count - value }),
+  up: value => state => ({ count: state.count + value })
+}
+
+const view = (state, actions) =>
+  state.count > 3 ? (
+    <div>
+      upper than 3<h2>{state.count}</h2>
+      <button onclick={() => actions.down(1)} disabled={state.count <= 0}>
+        ー
+      </button>
+      <button onclick={() => actions.up(1)}>＋</button>
+    </div>
+  ) : (
+    <main>
+      <h1>{state.count}</h1>
+      <button onclick={() => actions.down(1)} disabled={state.count <= 0}>
+        ー
+      </button>
+      <button onclick={() => actions.up(1)}>＋</button>
+    </main>
+  )
+
+app(state, actions, view, document.body)

--- a/sandbox/webpack.config.js
+++ b/sandbox/webpack.config.js
@@ -1,0 +1,62 @@
+const webpack = require("webpack")
+const path = require("path")
+const HtmlWebpackPlugin = require("html-webpack-plugin")
+
+const outputDir = path.resolve(__dirname, "./dist")
+const appSrc = path.resolve(__dirname, "src")
+const hyperappSrc = path.resolve(__dirname, "..", "src")
+const createAlias = () => ({ hyperapp: hyperappSrc })
+
+module.exports = {
+  entry: {
+    index: [`${__dirname}/src/index.js`]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      hash: true,
+      filename: "index.html",
+      template: "./index.html",
+      chunks: ["index"],
+      inject: "body"
+    }),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.LoaderOptionsPlugin({
+      debug: true,
+      minimize: false
+    })
+  ],
+  output: {
+    path: outputDir,
+    filename: "[name].js"
+  },
+  resolve: {
+    modules: ["node_modules"],
+    extensions: [".js", ".css"],
+    descriptionFiles: ["package.json"],
+    alias: {
+      hyperapp: path.resolve(__dirname, "..", "src", "index.js")
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ["babel-loader"]
+      },
+      {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"]
+      }
+    ]
+  },
+  devtool: "inline-source-map",
+  devServer: {
+    host: "0.0.0.0",
+    hot: true,
+    contentBase: outputDir,
+    port: 8008,
+    inline: true,
+    disableHostCheck: true
+  }
+}


### PR DESCRIPTION
hi. 
I created a sandbox environment that you can run it while touching the hyperapp code at your hand.
hyperapp is a light application just having about 400 lines and it's very lighter than React.js, vue.js, etc. So it's suitable to understand about virtual dom and how to implement it.
However, it is difficult to understand it only by reading the code, so I think that it is good to understand while touching the code.
Actually, I use this sandbox in my local and it very helps me understand.
So, How was it thought that it would be nice to have this environment officially?

the way to use sandbox
```sh
npm i
cd ./sandbox
npm i
yarn start # start http://localhost:8008/
```